### PR TITLE
Fix Safari version detection

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -8,19 +8,19 @@
 (function (undefined) {
 
     'use strict';
-    
+
     var mapper = {
-    
+
         regex : function () {
-        
+
             var result, i, j, k, l, m, args = arguments;
-            
+
             // loop through all regexes maps
             for (i = 0; i < args.length; i += 2) {
-            
+
                 var regex = args[i],       // odd sequence (0,2,4,..)
                     props = args[i + 1];   // even sequence (1,3,5,..)
-                
+
                 // construct object barebones
                 if (typeof result === 'undefined') {
                     result = {};
@@ -35,7 +35,7 @@
                         return result;
                     }
                 }
-                
+
                 // try matching uastring with regexes
                 for (j = 0; j < regex.length; j++) {
                     l = regex[j].exec(this.getUA());
@@ -57,14 +57,14 @@
                         break;
                     }
                 }
-                
+
                 if(!!l) break; // break the loop immediately if match found
             }
             return result;
         },
-    
+
         string : function (str, map) {
-        
+
             for (var i in map) {
                 if (map.hasOwnProperty(i)) {
                     if (typeof map[i] === 'object' && map[i].length > 0) {
@@ -98,7 +98,7 @@
             }
         }
     };
-    
+
     var regexes = {
 
         browser : [[
@@ -108,29 +108,31 @@
             /(opera\smobi)\/((\d+)?[\w\.-]+)/i,                                 // Opera Mobile
             /(opera).+version\/((\d+)?[\w\.]+)/i,                               // Opera > 9.80
             /(opera)[\/\s]+((\d+)?[\w\.]+)/i,                                   // Opera < 9.80
-            
+
             // Mixed
             /(kindle)\/((\d+)?[\w\.]+)/i,                                       // Kindle
             /(lunascape|maxthon|netfront|jasmine|blazer)[\/\s]?((\d+)?[\w\.]+)/i,
                                                                                 // Lunascape/Maxthon/Netfront/Jasmine/Blazer
-            
+
             // Trident based
             /(avant\sbrowser|iemobile|slimbrowser)[\/\s]?((\d+)?[\w\.]*)/i,     // Avant/IEMobile/SlimBrowser
             /ms(ie)\s((\d+)?[\w\.]+)/i,                                         // Internet Explorer
 
             // Webkit/KHTML based
-            /(chromium|flock|rockmelt|midori|epiphany|silk|skyfire|series60|bolt)\/((\d+)?[\w\.]+)/i, 
+            /(chromium|flock|rockmelt|midori|epiphany|silk|skyfire|series60|bolt)\/((\d+)?[\w\.]+)/i,
                                                                                 // Chromium/Flock/RockMelt/Midori/Epiphany/Silk/Skyfire/S60/Bolt
             /(chrome|omniweb|arora|dolfin|[tizenoka]{5}\s?browser)\/((\d+)?[\w\.]+)/i,
                                                                                 // Chrome/OmniWeb/Arora/Dolphin/Tizen/Nokia
             ], ['name', 'version', 'major'], [
             /(?:android.+(crmo|crios))\/((\d+)?[\w\.]+)/i,                      // Chrome for Android/iOS
             ], [['name', 'Chrome'], 'version', 'major'], [
-            /(mobile\ssafari|safari|konqueror)\/((\d+)?[\w\.]+)/i,              // Safari/Konqueror
+            /version\/((\d+)?[\w\.]+).+(mobile\s?safari|safari)/i               // Safari & Safari Mobile
+            ], [ 'version', 'major', 'name'], [
+            /(konqueror)\/((\d+)?[\w\.]+)/i,                                    // Konqueror
             /(applewebkit|khtml)\/((\d+)?[\w\.]+)/i,
 
             // Gecko based
-            /(iceweasel|camino|fennec|maemo\sbrowser|minimo)[\/\s]?((\d+)?[\w\.\+]+)/i,  
+            /(iceweasel|camino|fennec|maemo\sbrowser|minimo)[\/\s]?((\d+)?[\w\.\+]+)/i,
                                                                                 // Iceweasel/Camino/Fennec/Maemo/Minimo
             /(firefox|seamonkey|netscape|navigator|k-meleon|icecat|iceape)\/((\d+)?[\w\.]+)/i,
                                                                                 // Firefox/SeaMonkey/Netscape/K-Meleon/IceCat/IceApe
@@ -141,7 +143,7 @@
             /(gobrowser)\/?[\d\.]*/i                                            // GoBrowser
             ], ['name', 'version', 'major']
         ],
-        
+
         device : [[
 
             /\(((ipad|playbook));/i,                                            // iPad/PlayBook
@@ -153,31 +155,31 @@
 
             /\(((ip[honed]+));/i,                                               // iPod/iPhone
             /(blackberry)[\s-]?(\w+)/i,                                         // BlackBerry
-            /(blackberry|benq|palm(?=\-)|sonyericsson|acer|asus|dell|huawei|meizu|motorola)[\s_-]?([\w-]+)*/i,  
+            /(blackberry|benq|palm(?=\-)|sonyericsson|acer|asus|dell|huawei|meizu|motorola)[\s_-]?([\w-]+)*/i,
                                                                                 // BenQ/Palm/Sony-Ericsson/Acer/Asus/Dell/Huawei/Meizu/Motorola
             /(hp)\s([\w\s]+\w)/i,                                               // HP iPAQ
             /(asus)-?(\w+)/i                                                    // Asus
             ], ['vendor', 'model', ['type', 'Mobile']], [
-            
+
             /android.+((transfo[prime\s]{4,10}\s\w+|eeepc|slider\s\w+))/i       // Asus Tablets
             ], [['vendor', 'Asus'], 'model', ['type', 'Tablet']], [
-            
+
             /(sony)\s(tablet\s[ps])/i                                           // Sony Tablets
             ], ['vendor', 'model', ['type', 'Tablet']], [
-            
+
             /(nintendo|playstation)\s([wids3portablev]+)/i                      // Nintendo/Playstation
             ], ['vendor', 'model', ['type', 'Console']], [
-            
+
             /(htc)[;_\s-]+([\w\s]+(?=\))|\w+)*/i,                               // HTC
             /(zte)-(\w+)*/i                                                     // ZTE
             ], ['vendor', ['model', /_/g, ' '], ['type', 'Mobile']], [
-                        
+
             /\s((milestone|droid[2x]?))[globa\s]*\sbuild\//i,                   // Motorola
             /(mot)[\s-]?(\w+)*/i
-            ], [['vendor', 'Motorola'], 'model', ['type', 'Mobile']], [            
+            ], [['vendor', 'Motorola'], 'model', ['type', 'Mobile']], [
             /android.+\s((mz60\d|xoom[\s2]{0,2}))\sbuild\//i
             ], [['vendor', 'Motorola'], 'model', ['type', 'Tablet']], [
-            
+
             /android.+((sch-i[89]0\d|shw-m380s|gt-p\d{4}|gt-n8000|sgh-t8[56]9))/i
             ], [['vendor', 'Samsung'], 'model', ['type', 'Tablet']], [          // Samsung
             /((s[cgp]h-\w+|gt-\w+|galaxy\snexus))/i,
@@ -186,20 +188,20 @@
             ], [['vendor', 'Samsung'], 'model', ['type', 'Mobile']], [
             /(sie)-(\w+)*/i                                                     // Siemens
             ], [['vendor', 'Siemens'], 'model', ['type', 'Mobile']], [
-            
+
             /(maemo|nokia).*(n900|lumia\s\d+)/i,                                // Nokia
             /(nokia)[\s_-]?([\w-]+)*/i
             ], [['vendor', 'Nokia'], 'model', ['type', 'Mobile']], [
-            
+
             /android\s3\.[\s\w-;]{10}((a\d{3}))/i                               // Acer
             ], [['vendor', 'Acer'], 'model', ['type', 'Tablet']], [
-            
+
             /android\s3\.[\s\w-;]{10}(lg?)-([06cv9]{3,4})/i                     // LG
             ], [['vendor', 'LG'], 'model', ['type', 'Tablet']], [
             /(lg)[e;\s-\/]+(\w+)*/i
             ], [['vendor', 'LG'], 'model', ['type', 'Mobile']]
         ],
-        
+
         engine : [[
 
             /(presto)\/([\w\.]+)/i,                                             // Presto
@@ -208,9 +210,9 @@
             ], ['name', 'version'], [
 
             /rv\:([\w\.]+).*(gecko)/i                                           // Gecko
-            ], ['version', 'name']            
+            ], ['version', 'name']
         ],
-        
+
         os : [[
 
             // Windows based
@@ -218,7 +220,7 @@
             ], ['name', ['version', mapper.string, maps.os.windows.version]], [
             /(win(?=3|9|n)|win\s9x\s)([nt\d\.]+)/i
             ], [['name', 'Windows'], ['version', mapper.string, maps.os.windows.version]], [
-            
+
             // Mobile/Embedded OS
             /(blackberry).+version\/([\w\.]+)/i,                                // Blackberry
             /(tizen)\/([\w\.]+)/i,                                              // Tizen
@@ -227,7 +229,7 @@
             ], ['name', 'version'], [
             /(symbian\s?os|symbos|s60(?=;))[\/\s-]?([\w\.]+)*/i                 // Symbian
             ], [['name', 'Symbian'], 'version'],[
-            
+
             /(nintendo|playstation)\s([wids3portable]+)/i,                      // Nintendo/Playstation
 
             // GNU/Linux based
@@ -258,7 +260,7 @@
             // Other
             /(haiku)\s(\w+)/i,                                                  // Haiku
             /(macintosh|unix|minix|beos)[\/\s]?()*/i                            // UNIX/Minix/BeOS
-            ], ['name', 'version']            
+            ], ['name', 'version']
         ]
     };
 
@@ -290,7 +292,7 @@
                 device  : this.getDevice()
             };
         };
-        
+
         this.getUA = function() {
             return ua;
         };
@@ -302,7 +304,7 @@
 
         this.setUA(ua);
     };
-        
+
     // check whether script is running inside node.js export as module
     if (typeof exports !== 'undefined' && this.toString() !== '[object DOMWindow]') {
         if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
Hello sir!

I recently used you excellent library in a project I work on, Popcorn Maker.

I noticed that your regex for the Safari browser wasn't working as it should so I have patched it up :D

Safari, like Opera, doesn't have the version number immediately following the name, they use a `Version` identifier. This wasn't being taken into account. Furthermore, the order of Version and browser name is also switched between Safari and Opera i.e. `Opera/9.8 Version/12` and `Version/6.0.1 Safari/536.12.123`

I fixed all that up so that it'd work with Safari. There's also some removal of end of line whitespace that was stripped by my editor automatically.
