### PR TITLE
Fix google closure compiler JSC_TRAILING_COMMA errors

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -326,13 +326,13 @@
             ], [[NAME, 'Solaris'], VERSION], [
 
             // BSD based
-            /\s(\w*bsd|dragonfly)\s?([\w\.]+)*/i,                               // FreeBSD/NetBSD/OpenBSD/DragonFly
+            /\s(\w*bsd|dragonfly)\s?([\w\.]+)*/i                                // FreeBSD/NetBSD/OpenBSD/DragonFly
             ], [NAME, VERSION],[
 
-            /(ip[honead]+)(?:.*os\s*([\w]+)*\slike\smac|;\sopera)/i,            // iOS
+            /(ip[honead]+)(?:.*os\s*([\w]+)*\slike\smac|;\sopera)/i             // iOS
             ], [[NAME, 'iOS'], [VERSION, /_/g, '.']], [
 
-            /(mac\sos\sx)\s?([\w\s\.]+\w)*/i,                                   // Mac OS
+            /(mac\sos\sx)\s?([\w\s\.]+\w)*/i                                    // Mac OS
             ], [NAME, [VERSION, /_/g, '.']], [
 
             // Other


### PR DESCRIPTION
When running ua-parser.js though gcc I get these errors.

Paste:

```
// ==ClosureCompiler==
// @compilation_level SIMPLE_OPTIMIZATIONS
// @output_file_name default.js
// @code_url https://raw.github.com/faisalman/ua-parser-js/master/ua-parser.js
// ==/ClosureCompiler==
```

into: http://closure-compiler.appspot.com/home to see the errors.
