### PR TITLE
Add device detection for Lenovo tablet

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -376,7 +376,10 @@
             /((nexus\s4))/i,
             /(lg)[e;\s-\/]+(\w+)*/i
             ], [[VENDOR, 'LG'], MODEL, [TYPE, MOBILE]], [
-
+                
+             /android.+((IdeaTab[A-Za-z0-9\-\s]+))/i                               // Lenovo
+            ], [[VENDOR, 'Lenovo'], MODEL, [TYPE, TABLET]], [
+                
             /(mobile|tablet);.+rv\:.+gecko\//i                                  // Unidentifiable
             ], [TYPE, VENDOR, MODEL]
         ],


### PR DESCRIPTION
Lenovo tablet detection is missing. 
example of possible userAgent string: <code>"Mozilla/5.0 (Linux; Android 4.0.3; IdeaTab A2107A-F Build/ IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19"</code>
