### PR TITLE
Added Samsung Galaxy Note III

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -481,7 +481,7 @@
 
             /android.+((sch-i[89]0\d|shw-m380s|gt-p\d{4}|gt-n8000|sgh-t8[56]9|nexus 10))/i
             ], [[VENDOR, 'Samsung'], MODEL, [TYPE, TABLET]], [                  // Samsung
-            /((s[cgp]h-\w+|gt-\w+|galaxy\snexus))/i,
+            /((s[cgp]h-\w+|gt-\w+|galaxy\snexus|sm-n900))/i,
             /(sam[sung]*)[\s-]*(\w+-?[\w-]*)*/i,
             /sec-((sgh\w+))/i
             ], [[VENDOR, 'Samsung'], MODEL, [TYPE, MOBILE]], [


### PR DESCRIPTION
Added Samsung Galaxy Note III - phablet to "Samsung mobile" expression. User agent strings; http://www.webapps-online.com/online-tools/user-agent-strings/dv/brand125499/samsung-galaxy-note-iii
