### PR TITLE
Microsoft Edge is not IE12

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -253,9 +253,11 @@
                                                                                 // Chromium/Flock/RockMelt/Midori/Epiphany/Silk/Skyfire/Bolt/Iron
             ], [NAME, VERSION], [
 
-            /(trident).+rv[:\s]([\w\.]+).+like\sgecko/i,                        // IE11
-            /(Edge)\/((\d+)?[\w\.]+)/i                                          // IE12
+            /(trident).+rv[:\s]([\w\.]+).+like\sgecko/i                         // IE11
             ], [[NAME, 'IE'], VERSION], [
+
+            /(edge)\/((\d+)?[\w\.]+)/i                                          // Microsoft Edge
+            ], [NAME, VERSION], [
 
             /(yabrowser)\/([\w\.]+)/i                                           // Yandex
             ], [[NAME, 'Yandex'], VERSION], [

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -690,11 +690,11 @@
         }
     },
     {
-        "desc"    : "Windows 10 EI",
+        "desc"    : "Microsoft Edge",
         "ua"      : "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0",
         "expect"  : 
         {
-            "name"    : "IE",
+            "name"    : "Edge",
             "version" : "12.0",
             "major"   : "12"
         }


### PR DESCRIPTION
Moved Edge engine detection to its own browser; Microsoft Edge is a new browser, and should not be detected as IE.