### PR TITLE
Reference window as global if available

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -865,4 +865,4 @@
         };
     }
 
-})(this);
+})(typeof window === 'object' ? window : this);


### PR DESCRIPTION
This change will use `window` by default if it exists so that `browserify` and `Webpack` builds do not need to do something like

```javascript
var parser = new UAParser(window.navigator.userAgent)
```

See issue https://github.com/faisalman/ua-parser-js/issues/84