### PR TITLE
Implemented user agent id for Galaxy S6 + Safari

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,8 +27,8 @@ Firebird, Firefox, Flock, GoBrowser, iCab, ICE Browser, IceApe, IceCat, IceDrago
 Iceweasel, IE [Mobile], Iron, Jasmine, K-Meleon, Konqueror, Kindle, Links, 
 Lunascape, Lynx, Maemo, Maxthon, Midori, Minimo, MIUI Browser, [Mobile] Safari, 
 Mosaic, Mozilla, Netfront, Netscape, NetSurf, Nokia, OmniWeb, Opera [Mini/Mobi/Tablet], 
-Phoenix, Polaris, QQBrowser, RockMelt, Silk, Skyfire, SeaMonkey, SlimBrowser, Swiftfox, 
-Tizen, UCBrowser, Vivaldi, w3m, Yandex
+PhantomJS, Phoenix, Polaris, QQBrowser, RockMelt, Silk, Skyfire, SeaMonkey, SlimBrowser,
+Swiftfox, Tizen, UCBrowser, Vivaldi, w3m, Yandex
 
 # 'browser.version' determined dynamically
 ```

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -249,7 +249,7 @@
 
             // Webkit/KHTML based
             /(rekonq)\/([\w\.]+)*/i,                                            // Rekonq
-            /(chromium|flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt|iron|vivaldi)\/([\w\.-]+)/i
+            /(chromium|flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt|iron|vivaldi|phantomjs)\/([\w\.-]+)/i
                                                                                 // Chromium/Flock/RockMelt/Midori/Epiphany/Silk/Skyfire/Bolt/Iron
             ], [NAME, VERSION], [
 

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -590,7 +590,10 @@
             ], [[MODEL, /_/g, ' '], [VENDOR, 'Xiaomi'], [TYPE, MOBILE]], [
 
             /(mobile|tablet);.+rv\:.+gecko\//i                                  // Unidentifiable
-            ], [[TYPE, util.lowerize], VENDOR, MODEL]
+            ], [[TYPE, util.lowerize], VENDOR, MODEL], [
+
+            /android.+SM-G920I.+/i
+                ], [[MODEL, "Galaxy S6"], [VENDOR, "Samsung"], [TYPE, MOBILE]]
 
             /*//////////////////////////
             // TODO: move to string map

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -312,8 +312,8 @@
             /(mozilla)\/([\w\.]+).+rv\:.+gecko\/\d+/i,                          // Mozilla
 
             // Other
-            /(polaris|lynx|dillo|icab|doris|amaya|w3m|netsurf)[\/\s]?([\w\.]+)/i,
-                                                                                // Polaris/Lynx/Dillo/iCab/Doris/Amaya/w3m/NetSurf
+            /(polaris|lynx|dillo|icab|doris|amaya|w3m|netsurf|sleipnir)[\/\s]?([\w\.]+)/i,
+                                                                                // Polaris/Lynx/Dillo/iCab/Doris/Amaya/w3m/NetSurf/Sleipnir
             /(links)\s\(([\w\.]+)/i,                                            // Links
             /(gobrowser)\/?([\w\.]+)*/i,                                        // GoBrowser
             /(ice\s?browser)\/v?([\w\._]+)/i,                                   // ICE Browser

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -302,6 +302,8 @@
             // Gecko based
             /(navigator|netscape)\/([\w\.-]+)/i                                 // Netscape
             ], [[NAME, 'Netscape'], VERSION], [
+            /fxios\/([\w\.-]+)/i                                                // Firefox for iOS
+            ], [VERSION, [NAME, 'Firefox']], [
             /(swiftfox)/i,                                                      // Swiftfox
             /(icedragon|iceweasel|camino|chimera|fennec|maemo\sbrowser|minimo|conkeror)[\/\s]?([\w\.\+]+)/i,
                                                                                 // IceDragon/Iceweasel/Camino/Chimera/Fennec/Maemo/Minimo/Conkeror

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -540,6 +540,16 @@
         }
     },
     {
+        "desc"    : "PhantomJS",
+        "ua"      : "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.2 Safari/534.34",
+        "expect"  :
+        {
+            "name"    : "PhantomJS",
+            "version" : "1.9.2",
+            "major"   : "1"
+        }
+    },
+    {
         "desc"    : "Phoenix",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.2b) Gecko/20021029 Phoenix/0.4",
         "expect"  : 

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -130,6 +130,16 @@
         }
     },
     {
+        "desc"      : "Samsing Galaxy S6",
+        "ua"        : "Mozilla/5.0 (Linux; Android 5.0.2; SM-G920I build/lrx22g) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36",
+        "expect"    :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "Galaxy S6",
+            "type"    : "mobile"
+        }
+    },
+    {
         "desc"    : "Sony C5303 (Xperia SP)",
         "ua"      : "Mozilla/5.0 (Linux; Android 4.3; C5303 Build/12.1.A.1.205) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36",
         "expect"  :

--- a/test/os-test.json
+++ b/test/os-test.json
@@ -601,5 +601,14 @@
             "name"    : "Android",
             "version" : "4.2.1"
         }
+    },
+    {
+        "desc"    : "Samsing Galaxy S6",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.0.2; SM-G920I build/lrx22g) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "Android",
+            "version" : "5.0.2"
+        }
     }
 ]


### PR DESCRIPTION
{ ua: 'Mozilla/5.0 (Linux; Android 5.0.2; SM-G920I build/lrx22g) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36',
  browser: 
   { name: 'Chrome',
     version: '43.0.2357.92',
     major: '43' },
  engine: { version: '537.36', name: 'WebKit' },
  os: { name: 'Android', version: '5.0.2' },
  device: 
   { model: 'Galaxy S6',
     vendor: 'Samsung',
     type: 'mobile' },
  cpu: { architecture: undefined } }