### PR TITLE
Added Nexus 6 detection

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -543,7 +543,8 @@
                                                                                 // Motorola
             /\s(milestone|droid(?:[2-4x]|\s(?:bionic|x2|pro|razr))?(:?\s4g)?)[\w\s]+build\//i,
             /mot[\s-]?(\w+)*/i,
-            /(XT\d{3,4}) build\//i
+            /(XT\d{3,4}) build\//i,
+            /(nexus\s[6])/i
             ], [MODEL, [VENDOR, 'Motorola'], [TYPE, MOBILE]], [
             /android.+\s(mz60\d|xoom[\s2]{0,2})\sbuild\//i
             ], [MODEL, [VENDOR, 'Motorola'], [TYPE, TABLET]], [
@@ -574,7 +575,7 @@
             ], [[VENDOR, 'LG'], MODEL, [TYPE, TABLET]], [
             /(lg) netcast\.tv/i                                                 // LG SmartTV
             ], [VENDOR, MODEL, [TYPE, SMARTTV]], [
-            /(nexus\s[45])/i,                                                   // LG
+            /(nexus\s[456])/i,                                                   // LG
             /lg[e;\s\/-]+(\w+)*/i
             ], [MODEL, [VENDOR, 'LG'], [TYPE, MOBILE]], [
 

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -40,6 +40,16 @@
         }
     },
     {
+        "desc"    : "Motorola Nexus 6",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.20 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Motorola",
+            "model"   : "Nexus 6",
+            "type"    : "mobile"
+        }
+    },
+    {
         "desc"    : "Motorola Droid RAZR 4G",
         "ua"      : "Mozilla/5.0 (Linux; U; Android 2.3; xx-xx; DROID RAZR 4G Build/6.5.1-73_DHD-11_M1-29) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
         "expect"  :


### PR DESCRIPTION
Correctly identifies a Nexus 6 device as being a Motorola mobile device.