### PR TITLE
Detect Nexus 6 as Motorola only.

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -575,7 +575,7 @@
             ], [[VENDOR, 'LG'], MODEL, [TYPE, TABLET]], [
             /(lg) netcast\.tv/i                                                 // LG SmartTV
             ], [VENDOR, MODEL, [TYPE, SMARTTV]], [
-            /(nexus\s[456])/i,                                                   // LG
+            /(nexus\s[45])/i,                                                   // LG
             /lg[e;\s\/-]+(\w+)*/i
             ], [MODEL, [VENDOR, 'LG'], [TYPE, MOBILE]], [
 


### PR DESCRIPTION
The commit https://github.com/faisalman/ua-parser-js/commit/3964971c3847ebeb80fc88f080b1879c33c7a774 added Nexus 6 to LG and Motorola, but it should be Motorola only, as stated in the according commit message as well.