### PR TITLE
travis update: node_js stable, cache node_modules, sudo false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: node_js
 node_js:
-  - "0.10"
+    - stable
+    - "0.10"
+
 notifications:
   email: false
+
+cache:
+    directories:
+        - node_modules
+
+sudo: false


### PR DESCRIPTION
Added node_js stable to test on latest V8. Just in case there are any breaking changes, we should be able to catch them.

Cache node_modules: I thought this might be usefull ([discusion](https://github.com/corejavascript/typeahead.js/pull/22)).

sudo: false - this is [recomended](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) for a number of reasons.