### PR TITLE
Treat all Android smartphones as mobile

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -596,7 +596,7 @@
             /android.+(mi[\s\-_]*(?:one|one[\s_]plus)?[\s_]*(?:\d\w)?)\s+build/i    // Xiaomi Mi
             ], [[MODEL, /_/g, ' '], [VENDOR, 'Xiaomi'], [TYPE, MOBILE]], [
 
-            /(mobile|tablet);.+rv\:.+gecko\//i                                  // Unidentifiable
+            /(mobile|tablet)/i                                                  // Unidentifiable
             ], [[TYPE, util.lowerize], VENDOR, MODEL]
 
             /*//////////////////////////


### PR DESCRIPTION
Generalize the check for an unidentifiable mobile or tablet to correctly categorize unidentifiable Android smartphones as "mobile".