### PR TITLE
add support for WeChat

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -267,10 +267,13 @@
             /(comodo_dragon)\/([\w\.]+)/i                                       // Comodo Dragon
             ], [[NAME, /_/g, ' '], VERSION], [
 
-            /(chrome|omniweb|arora|[tizenoka]{5}\s?browser)\/v?([\w\.]+)/i,
-                                                                                // Chrome/OmniWeb/Arora/Tizen/Nokia
-            /(qqbrowser)[\/\s]?([\w\.]+)/i
-                                                                                // QQBrowser
+            /(chrome|omniweb|arora|[tizenoka]{5}\s?browser)\/v?([\w\.]+)/i      // Chrome/OmniWeb/Arora/Tizen/Nokia
+            ], [NAME, VERSION], [
+
+            /(MicroMessenger)\/([\w\.]+)/i                                      // WeChat
+            ], [[NAME, 'WeChat'], VERSION], [
+
+            /(qqbrowser)[\/\s]?([\w\.]+)/i                                      // QQBrowser
             ], [NAME, VERSION], [
 
             /(uc\s?browser)[\/\s]?([\w\.]+)/i,

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -690,6 +690,26 @@
         }
     },
     {
+        "desc": "WeChat on iOS",
+        "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 8_4_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12H321 MicroMessenger/6.3.6 NetType/WIFI Language/zh_CN",
+        "expect":
+        {
+            "name": "WeChat",
+            "version": "6.3.6",
+            "major": "6"
+        }
+    },
+    {
+        "desc": "WeChat on Android",
+        "ua": "Mozilla/5.0 (Linux; U; Android 5.1; zh-cn; Lenovo K50-t5 Build/LMY47D) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025478 Mobile Safari/533.1 MicroMessenger/6.3.5.50_r1573191.640 NetType/WIFI Language/zh_CN",
+        "expect":
+        {
+            "name": "WeChat",
+            "version": "6.3.5.50_r1573191.640",
+            "major": "6"
+        }
+    },
+    {
         "desc"    : "Vivaldi",
         "ua"      : "Mozilla/5.0 (Windows NT 6.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Vivaldi/1.0.83.38 Safari/537.36",
         "expect"  : 


### PR DESCRIPTION
WeChat is used in China widely.
FIX #115 
