### PR TITLE
Fix detection of Firefox on iOS.

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -294,6 +294,9 @@
             /FBAV\/([\w\.]+);/i                                                 // Facebook App for iOS
             ], [VERSION, [NAME, 'Facebook']], [
 
+            /fxios\/([\w\.-]+)/i                                                // Firefox for iOS
+            ], [VERSION, [NAME, 'Firefox']], [
+
             /version\/([\w\.]+).+?mobile\/\w+\s(safari)/i                       // Mobile Safari
             ], [VERSION, [NAME, 'Mobile Safari']], [
 
@@ -310,8 +313,6 @@
             // Gecko based
             /(navigator|netscape)\/([\w\.-]+)/i                                 // Netscape
             ], [[NAME, 'Netscape'], VERSION], [
-            /fxios\/([\w\.-]+)/i                                                // Firefox for iOS
-            ], [VERSION, [NAME, 'Firefox']], [
             /(swiftfox)/i,                                                      // Swiftfox
             /(icedragon|iceweasel|camino|chimera|fennec|maemo\sbrowser|minimo|conkeror)[\/\s]?([\w\.\+]+)/i,
                                                                                 // IceDragon/Iceweasel/Camino/Chimera/Fennec/Maemo/Minimo/Conkeror

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -728,5 +728,15 @@
             "version" : "43.8",
             "major"   : "43"
         }
+    },
+    {
+        "desc"    : "Firefox iOS",
+        "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) FxiOS/1.1 Mobile/13B143 Safari/601.1.46",
+        "expect"  :
+        {
+            "name"    : "Firefox",
+            "version" : "1.1",
+            "major"   : "1"
+        }
     }
 ]


### PR DESCRIPTION
Firefox on iOS' ua string is also matched by the "Safari < 3.0" regular expression, unfortunately. Reordering the regular expressions so that the one for FxiOS matches first helps.

The downside: the `FxiOS` regexp is now listed in the category of WebKit based engines which is wrong. Don't know what the implications of moving the Gecko category above the WebKit category are. At least 16 of 379 of tests are failing then. @faisalman: What's your opinion on that?