### PR TITLE
UAParser is exposed globally to the window object. It can be used directly.

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,6 +7,5 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
-  api.export("UAParser");
   api.addFiles("src/ua-parser.js");
 });


### PR DESCRIPTION
Fix #137.

Reference:
meteor/meteor/issues/4105
