### PR TITLE
Add name to UA-Parser RequireJS module

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -848,7 +848,7 @@
     } else {
         // requirejs env (optional)
         if (typeof(define) === FUNC_TYPE && define.amd) {
-            define(function () {
+            define("ua-parser-js", [], function () {
                 return UAParser;
             });
         } else {


### PR DESCRIPTION
The issue was if I make the widget or something else which will be compiled with UAParser in one file and included to requirejs-enabled page with simple <script> tag. 

In this case there will be an error http://requirejs.org/docs/errors.html#mismatch

Adding name to module will not affect normal usage but will let this issue gone in pre-compiled scripts.