### PR TITLE
fix it for opera mini 8 above on iphone

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -233,8 +233,10 @@
             /(opera\s[mobiletab]+).+version\/([\w\.-]+)/i,                      // Opera Mobi/Tablet
             /(opera).+version\/([\w\.]+)/i,                                     // Opera > 9.80
             /(opera)[\/\s]+([\w\.]+)/i                                          // Opera < 9.80
-
             ], [NAME, VERSION], [
+
+            /(OPiOS)[\/\s]+([\w\.]+)/i                                          // Opera mini on iphone >= 8.0
+            ], [[NAME, 'Opera Mini'], VERSION], [
 
             /\s(opr)\/([\w\.]+)/i                                               // Opera Webkit
             ], [[NAME, 'Opera'], VERSION], [
@@ -534,7 +536,7 @@
             /(alcatel|geeksphone|huawei|lenovo|nexian|panasonic|(?=;\s)sony)[_\s-]?([\w-]+)*/i
                                                                                 // Alcatel/GeeksPhone/Huawei/Lenovo/Nexian/Panasonic/Sony
             ], [VENDOR, [MODEL, /_/g, ' '], [TYPE, MOBILE]], [
-                
+
             /(nexus\s9)/i                                                       // HTC Nexus 9
             ], [MODEL, [VENDOR, 'HTC'], [TYPE, TABLET]], [
 
@@ -656,7 +658,7 @@
             ], [VENDOR, MODEL, [TYPE, MOBILE]], [
             /(i-STYLE2.1)/i                                                     // i-mobile i-STYLE 2.1
             ], [[MODEL, 'i-STYLE 2.1'], [VENDOR, 'i-mobile'], [TYPE, MOBILE]], [
-            
+
             /(mobiistar touch LAI 512)/i                                        // mobiistar touch LAI 512
             ], [[MODEL, 'Touch LAI 512'], [VENDOR, 'mobiistar'], [TYPE, MOBILE]], [
 
@@ -858,7 +860,7 @@
     }
 
     // jQuery/Zepto specific (optional)
-    // Note: 
+    // Note:
     //   In AMD env the global scope should be kept clean, but jQuery is an exception.
     //   jQuery always exports to global scope, unless jQuery.noConflict(true) is used,
     //   and we should catch that.

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -2,7 +2,7 @@
     {
         "desc"    : "Android Browser on HTC Flyer (P510E)",
         "ua"      : "Mozilla/5.0 (Linux; U; Android 3.2.1; ru-ru; HTC Flyer P510e Build/HTK75C) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Android Browser",
             "version" : "4.0",
@@ -12,7 +12,7 @@
     {
         "desc"    : "Android Browser on Huawei Honor Glory II (U9508)",
         "ua"      : "Mozilla/5.0 (Linux; U; Android 4.0.4; ru-by; HUAWEI U9508 Build/HuaweiU9508) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 ACHEETAHI/2100050044",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Android Browser",
             "version" : "4.0",
@@ -22,7 +22,7 @@
     {
         "desc"    : "Arora",
         "ua"      : "Mozilla/5.0 (Windows; U; Windows NT 5.1; de-CH) AppleWebKit/523.15 (KHTML, like Gecko, Safari/419.3) Arora/0.2",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Arora",
             "version" : "0.2",
@@ -32,7 +32,7 @@
     {
         "desc"    : "Avant",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB5; Avant Browser; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Avant ",
             "version" : "undefined",
@@ -42,7 +42,7 @@
     {
         "desc"    : "Baidu",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; baidubrowser 1.x)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "baidu",
             "version" : "1.x",
@@ -52,7 +52,7 @@
     {
         "desc"    : "Bolt",
         "ua"      : "Mozilla/5.0 (X11; 78; CentOS; US-en) AppleWebKit/527+ (KHTML, like Gecko) Bolt/0.862 Version/3.0 Safari/523.15",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Bolt",
             "version" : "0.862",
@@ -62,7 +62,7 @@
     {
         "desc"    : "Camino",
         "ua"      : "Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.0.19) Gecko/2011091218 Camino/2.0.9 (like Firefox/3.0.19)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Camino",
             "version" : "2.0.9",
@@ -72,7 +72,7 @@
     {
         "desc"    : "Chimera",
         "ua"      : "Mozilla/5.0 (Macintosh; U; PPC Mac OS X; pl-PL; rv:1.0.1) Gecko/20021111 Chimera/0.6",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Chimera",
             "version" : "0.6",
@@ -82,7 +82,7 @@
     {
         "desc"    : "Chrome",
         "ua"      : "Mozilla/5.0 (Windows NT 6.2) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1090.0 Safari/536.6",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Chrome",
             "version" : "20.0.1090.0",
@@ -92,7 +92,7 @@
     {
         "desc"    : "Chrome on iOS",
         "ua"      : "Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Chrome",
             "version" : "19.0.1084.60",
@@ -102,7 +102,7 @@
     {
         "desc"    : "Chromium",
         "ua"      : "Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.7 (KHTML, like Gecko) Ubuntu/11.10 Chromium/16.0.912.21 Chrome/16.0.912.21 Safari/535.7",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Chromium",
             "version" : "16.0.912.21",
@@ -112,7 +112,7 @@
     {
         "desc"    : "Chrome on Android",
         "ua"      : "Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Chrome",
             "version" : "16.0.912.75",
@@ -122,7 +122,7 @@
     {
         "desc"    : "Dillo",
         "ua"      : "Dillo/2.2",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Dillo",
             "version" : "2.2",
@@ -132,7 +132,7 @@
     {
         "desc"    : "Dolphin",
         "ua"      : "Mozilla/5.0 (SCH-F859/F859DG12;U;NUCLEUS/2.1;Profile/MIDP-2.1 Configuration/CLDC-1.1;480*800;CTC/2.0) Dolfin/2.0",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Dolphin",
             "version" : "2.0",
@@ -142,7 +142,7 @@
     {
         "desc"    : "Doris",
         "ua"      : "Doris/1.15 [en] (Symbian)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Doris",
             "version" : "1.15",
@@ -152,7 +152,7 @@
     {
         "desc"    : "Epiphany",
         "ua"      : "Mozilla/5.0 (X11; U; FreeBSD i386; en-US; rv:1.7) Gecko/20040628 Epiphany/1.2.6",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Epiphany",
             "version" : "1.2.6",
@@ -162,7 +162,7 @@
     {
         "desc"    : "Firebird",
         "ua"      : "Mozilla/5.0 (Windows; U; Win98; en-US; rv:1.5) Gecko/20031007 Firebird/0.7",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Firebird",
             "version" : "0.7",
@@ -172,7 +172,7 @@
     {
         "desc"    : "Firefox",
         "ua"      : "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Firefox",
             "version" : "15.0a2",
@@ -182,7 +182,7 @@
     {
         "desc"    : "Fennec",
         "ua"      : "Mozilla/5.0 (X11; U; Linux armv61; en-US; rv:1.9.1b2pre) Gecko/20081015 Fennec/1.0a1",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Fennec",
             "version" : "1.0a1",
@@ -192,7 +192,7 @@
     {
         "desc"    : "Flock",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.3) Gecko/2008100716 Firefox/3.0.3 Flock/2.0",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Flock",
             "version" : "2.0",
@@ -202,7 +202,7 @@
     {
         "desc"    : "GoBrowser",
         "ua"      : "Nokia5700XpressMusic/GoBrowser/1.6.91",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "GoBrowser",
             "version" : "1.6.91",
@@ -212,7 +212,7 @@
     {
         "desc"    : "IceApe",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.19) Gecko/20110817 Iceape/2.0.14",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Iceape",
             "version" : "2.0.14",
@@ -222,7 +222,7 @@
     {
         "desc"    : "IceCat",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.3) Gecko/2008092921 IceCat/3.0.3-g1",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "IceCat",
             "version" : "3.0.3-g1",
@@ -232,7 +232,7 @@
     {
         "desc"    : "Iceweasel",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.0.16) Gecko/2009121610 Iceweasel/3.0.6 (Debian-3.0.6-3)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Iceweasel",
             "version" : "3.0.6",
@@ -242,7 +242,7 @@
     {
         "desc"    : "iCab",
         "ua"      : "iCab/2.9.5 (Macintosh; U; PPC; Mac OS X)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "iCab",
             "version" : "2.9.5",
@@ -252,7 +252,7 @@
     {
         "desc"    : "IEMobile",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) 320x240; VZW; Motorola-Q9c; Windows Mobile 6.1 Standard",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "IEMobile",
             "version" : "7.11",
@@ -262,7 +262,7 @@
     {
         "desc"    : "IE 11 with IE token",
         "ua"      : "Mozilla/5.0 (IE 11.0; Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "IE",
             "version" : "11.0",
@@ -272,7 +272,7 @@
     {
         "desc"    : "IE 11 without IE token",
         "ua"      : "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv 11.0) like Gecko",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "IE",
             "version" : "11.0",
@@ -282,7 +282,7 @@
     {
         "desc"    : "K-Meleon",
         "ua"      : "Mozilla/5.0 (Windows; U; Win98; en-US; rv:1.5) Gecko/20031016 K-Meleon/0.8.2",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "K-Meleon",
             "version" : "0.8.2",
@@ -292,17 +292,17 @@
     {
         "desc"    : "Kindle Browser",
         "ua"      : "Mozilla/4.0 (compatible; Linux 2.6.22) NetFront/3.4 Kindle/2.5 (screen 600x800; rotate)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Kindle",
             "version" : "2.5",
             "major"   : "2"
         }
-    }, 
+    },
     {
         "desc"    : "Konqueror",
         "ua"      : "Mozilla/5.0 (compatible; Konqueror/3.5; Linux; X11; x86_64) KHTML/3.5.6 (like Gecko) (Kubuntu)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Konqueror",
             "version" : "3.5",
@@ -312,7 +312,7 @@
     {
         "desc"    : "Lunascape",
         "ua"      : "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.1.2) Gecko/20090804 Firefox/3.5.2 Lunascape/5.1.4.5",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Lunascape",
             "version" : "5.1.4.5",
@@ -322,7 +322,7 @@
     {
         "desc"    : "Lynx",
         "ua"      : "Lynx/2.8.5dev.16 libwww-FM/2.14 SSL-MM/1.4.1 OpenSSL/0.9.6b",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Lynx",
             "version" : "2.8.5dev.16",
@@ -332,7 +332,7 @@
     {
         "desc"    : "Maemo Browser",
         "ua"      : "Mozilla/5.0 (X11; U; Linux armv7l; ru-RU; rv:1.9.2.3pre) Gecko/20100723 Firefox/3.5 Maemo Browser 1.7.4.8 RX-51 N900",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Maemo Browser",
             "version" : "1.7.4.8",
@@ -342,7 +342,7 @@
     {
         "desc"    : "Maxthon",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; SV1; Maxthon; .NET CLR 1.1.4322)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Maxthon",
             "version" : "undefined",
@@ -352,7 +352,7 @@
     {
         "desc"    : "Midori",
         "ua"      : "Midori/0.2.2 (X11; Linux i686; U; en-us) WebKit/531.2+",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Midori",
             "version" : "0.2.2",
@@ -362,7 +362,7 @@
     {
         "desc"    : "Minimo",
         "ua"      : "Mozilla/5.0 (X11; U; Linux armv6l; rv 1.8.1.5pre) Gecko/20070619 Minimo/0.020",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Minimo",
             "version" : "0.020",
@@ -372,7 +372,7 @@
     {
         "desc"    : "MIUI Browser on Xiaomi Hongmi WCDMA (HM2013023)",
         "ua"      : "Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; 2013023 Build/HM2013023) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "MIUI Browser",
             "version" : "1.0",
@@ -382,7 +382,7 @@
     {
         "desc"    : "Mobile Safari",
         "ua"      : "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Mobile Safari",
             "version" : "4.0.5",
@@ -392,7 +392,7 @@
     {
         "desc"    : "Mosaic",
         "ua"      : "NCSA_Mosaic/2.6 (X11; SunOS 4.1.3 sun4m)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Mosaic",
             "version" : "2.6",
@@ -402,7 +402,7 @@
     {
         "desc"    : "Mozilla",
         "ua"      : "Mozilla/5.0 (X11; U; SunOS sun4u; en-US; rv:1.7) Gecko/20070606",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Mozilla",
             "version" : "5.0",
@@ -412,7 +412,7 @@
     {
         "desc"    : "MSIE",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 5.0b1; Mac_PowerPC)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "IE",
             "version" : "5.0b1",
@@ -422,7 +422,7 @@
     {
         "desc"    : "NetFront",
         "ua"      : "Mozilla/4.0 (PDA; Windows CE/1.0.1) NetFront/3.0",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "NetFront",
             "version" : "3.0",
@@ -432,7 +432,7 @@
     {
         "desc"    : "Netscape on Windows ME",
         "ua"      : "Mozilla/5.0 (Windows; U; Win 9x 4.90; en-US; rv:1.8.1.8pre) Gecko/20071015 Firefox/2.0.0.7 Navigator/9.0",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Netscape",
             "version" : "9.0",
@@ -442,7 +442,7 @@
     {
         "desc"    : "Netscape on Windows 2000",
         "ua"      : "Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.7.5) Gecko/20050519 Netscape/8.0.1",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Netscape",
             "version" : "8.0.1",
@@ -452,7 +452,7 @@
     {
         "desc"    : "Nokia Browser",
         "ua"      : "Mozilla/5.0 (Symbian/3; Series60/5.2 NokiaN8-00/025.007; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.3.1.37 Mobile Safari/533.4 3gpp-gba",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "NokiaBrowser",
             "version" : "7.3.1.37",
@@ -462,7 +462,7 @@
     {
         "desc"    : "OmniWeb",
         "ua"      : "Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-US) AppleWebKit/85 (KHTML, like Gecko) OmniWeb/v558.48",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "OmniWeb",
             "version" : "558.48",
@@ -472,7 +472,7 @@
     {
         "desc"    : "Opera > 9.80",
         "ua"      : "Opera/9.80 (X11; Linux x86_64; U; Linux Mint; en) Presto/2.2.15 Version/10.10",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Opera",
             "version" : "10.10",
@@ -482,7 +482,7 @@
     {
         "desc"    : "Opera < 9.80 on Windows",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 5.0; Windows 95) Opera 6.01 [en]",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Opera",
             "version" : "6.01",
@@ -492,7 +492,7 @@
     {
         "desc"    : "Opera < 9.80 on OSX",
         "ua"      : "Opera/8.5 (Macintosh; PPC Mac OS X; U; en)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Opera",
             "version" : "8.5",
@@ -502,7 +502,7 @@
     {
         "desc"    : "Opera Mobile",
         "ua"      : "Opera/9.80 (Android 2.3.5; Linux; Opera Mobi/ADR-1111101157; U; de) Presto/2.9.201 Version/11.50",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Opera Mobi",
             "version" : "11.50",
@@ -512,7 +512,7 @@
     {
         "desc"    : "Opera Webkit",
         "ua"      : "Mozilla/5.0 AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.52315",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Opera",
             "version" : "14.0.1025.52315",
@@ -522,7 +522,7 @@
     {
         "desc"    : "Opera Mini",
         "ua"      : "Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21214/19.916; U; en) Presto/2.5.25",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Opera Mini",
             "version" : "5.1.21214",
@@ -530,9 +530,19 @@
         }
     },
     {
+        "desc"    : "Opera Mini 8 above on iPhone",
+        "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 9_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) OPiOS/12.1.1.98980 Mobile/13C75 Safari/9537.53",
+        "expect"  :
+        {
+            "name"    : "Opera Mini",
+            "version" : "12.1.1.98980",
+            "major"   : "12"
+        }
+    },
+    {
         "desc"    : "Opera Tablet",
         "ua"      : "Opera/9.80 (Windows NT 6.1; Opera Tablet/15165; U; en) Presto/2.8.149 Version/11.1",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Opera Tablet",
             "version" : "11.1",
@@ -552,7 +562,7 @@
     {
         "desc"    : "Phoenix",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.2b) Gecko/20021029 Phoenix/0.4",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Phoenix",
             "version" : "0.4",
@@ -562,7 +572,7 @@
     {
         "desc"    : "Polaris",
         "ua"      : "LG-LX600 Polaris/6.0 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Polaris",
             "version" : "6.0",
@@ -572,7 +582,7 @@
     {
         "desc"    : "RockMelt",
         "ua"      : "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/534.7 (KHTML, like Gecko) RockMelt/0.8.36.78 Chrome/7.0.517.44 Safari/534.7",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "RockMelt",
             "version" : "0.8.36.78",
@@ -582,7 +592,7 @@
     {
         "desc"    : "Safari",
         "ua"      : "Mozilla/5.0 (Windows; U; Windows NT 5.2; en-US) AppleWebKit/533.17.8 (KHTML, like Gecko) Version/5.0.1 Safari/533.17.8",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Safari",
             "version" : "5.0.1",
@@ -592,7 +602,7 @@
     {
         "desc"    : "Safari < 3.0",
         "ua"      : "Mozilla/5.0 (Macintosh; U; PPC Mac OS X; sv-se) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Safari",
             "version" : "2.0.4",
@@ -602,7 +612,7 @@
     {
         "desc"    : "SeaMonkey",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1b4pre) Gecko/20090405 SeaMonkey/2.0b1pre",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "SeaMonkey",
             "version" : "2.0b1pre",
@@ -612,7 +622,7 @@
     {
         "desc"    : "Silk Browser",
         "ua"      : "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-84)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Silk",
             "version" : "1.1.0-84",
@@ -622,7 +632,7 @@
     {
         "desc"    : "Skyfire",
         "ua"      : "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Skyfire",
             "version" : "2.0",
@@ -632,7 +642,7 @@
     {
         "desc"    : "SlimBrowser",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; SlimBrowser)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Slim",
             "version" : "undefined",
@@ -642,7 +652,7 @@
     {
         "desc"    : "Swiftfox",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Firefox/2.0 (Swiftfox)",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Swiftfox",
             "version" : "undefined",
@@ -652,7 +662,7 @@
     {
         "desc"    : "Tizen Browser",
         "ua"      : "Mozilla/5.0 (Linux; U; Tizen/1.0 like Android; en-us; AppleWebKit/534.46 (KHTML, like Gecko) Tizen Browser/1.0 Mobile",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Tizen Browser",
             "version" : "1.0",
@@ -662,7 +672,7 @@
     {
         "desc"    : "UC Browser on Samsung",
         "ua"      : "Mozilla/5.0 (Java; U; Pt-br; samsung-gt-s5620) UCBrowser8.2.1.144/69/352/UCWEB Mobile UNTRUSTED/1.0",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "UCBrowser",
             "version" : "8.2.1.144",
@@ -672,7 +682,7 @@
     {
         "desc"    : "UC Browser on Nokia",
         "ua"      : "Mozilla/5.0 (S60V3; U; en-in; NokiaN73)/UC Browser8.4.0.159/28/351/UCWEB Mobile",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "UCBrowser",
             "version" : "8.4.0.159",
@@ -682,7 +692,7 @@
     {
         "desc"    : "UC Browser J2ME",
         "ua"      : "UCWEB/2.0 (MIDP-2.0; U; zh-CN; HTC EVO 3D X515m) U2/1.0.0 UCBrowser/10.4.0.558 U2/1.0.0 Mobile",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "UCBrowser",
             "version" : "10.4.0.558",
@@ -692,7 +702,7 @@
     {
         "desc"    : "UC Browser J2ME 2",
         "ua"      : "JUC (Linux; U; 2.3.5; zh-cn; GT-I9100; 480*800) UCWEB7.9.0.94/139/800",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "UCBrowser",
             "version" : "7.9.0.94",
@@ -702,7 +712,7 @@
     {
         "desc"    : "Vivaldi",
         "ua"      : "Mozilla/5.0 (Windows NT 6.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Vivaldi/1.0.83.38 Safari/537.36",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Vivaldi",
             "version" : "1.0.83.38",
@@ -712,7 +722,7 @@
     {
         "desc"    : "Yandex",
         "ua"      : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/536.5 (KHTML, like Gecko) YaBrowser/1.0.1084.5402 Chrome/19.0.1084.5402 Safari/536.5",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Yandex",
             "version" : "1.0.1084.5402",
@@ -722,7 +732,7 @@
     {
         "desc"    : "Microsoft Edge",
         "ua"      : "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0",
-        "expect"  : 
+        "expect"  :
         {
             "name"    : "Edge",
             "version" : "12.0",


### PR DESCRIPTION
Mozilla/5.0 (iPhone; CPU iPhone OS 9_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) OPiOS/12.1.1.98980 Mobile/13C75 Safari/9537.53

now, browser'value is safari. and i fixed. and remove tailing space.

https://dev.opera.com/blog/opera-mini-8-for-ios/