### PR TITLE
Get SmartTV device by HbbTV part

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -67,6 +67,9 @@
         },
         major : function (version) {
             return typeof(version) === STR_TYPE ? version.split(".")[0] : undefined;
+        },
+        trim : function (str) {
+          return str.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
         }
     };
 
@@ -474,6 +477,9 @@
 
         device : [[
 
+            /hbbtv\/\d+\.\d+\.\d+\s+\([\w\s]*;\s*(\w[^;]*);([^;]*)/i            // HbbTV devices
+            ], [[VENDOR, util.trim], [MODEL, util.trim], [TYPE, SMARTTV]], [
+
             /\((ipad|playbook);[\w\s\);-]+(rim|apple)/i                         // iPad/PlayBook
             ], [MODEL, VENDOR, [TYPE, TABLET]], [
 
@@ -564,8 +570,8 @@
             /(sam[sung]*)[\s-]*(\w+-?[\w-]*)*/i,
             /sec-((sgh\w+))/i
             ], [[VENDOR, 'Samsung'], MODEL, [TYPE, MOBILE]], [
-            /(samsung);smarttv/i
-            ], [VENDOR, MODEL, [TYPE, SMARTTV]], [
+            /hbbtv.+maple;(\d+)/i
+            ], [[MODEL, /^/, 'SmartTV'], [VENDOR, 'Samsung'], [TYPE, SMARTTV]], [
 
             /\(dtv[\);].+(aquos)/i                                              // Sharp
             ], [MODEL, [VENDOR, 'Sharp'], [TYPE, SMARTTV]], [

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -100,6 +100,16 @@
         }
     },
     {
+        "desc"    : "Philips SmartTV",
+        "ua"      : "Opera/9.80 HbbTV/1.1.1 (; Philips; ; ; ; ) NETTV/4.0.2; en) Version/11.60",
+        "expect"  :
+        {
+            "vendor"  : "Philips",
+            "model"   : "",
+            "type"    : "smarttv"
+        }
+    },
+    {
         "desc"    : "Kindle Fire HD",
         "ua"      : "Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.4 Mobile Safari/535.19 Silk-Accelerated=true",
         "expect"  :
@@ -137,6 +147,36 @@
             "vendor"  : "Samsung",
             "model"   : "SM-T520",
             "type"    : "tablet"
+        }
+    },
+    {
+        "desc"    : "Samsung SmartTV2011",
+        "ua"      : "HbbTV/1.1.1 (;;;;;) Maple;2011",
+        "expect"  :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "SmartTV2011",
+            "type"    : "smarttv"
+        }
+    },
+    {
+        "desc"    : "Samsung SmartTV2012",
+        "ua"      : "HbbTV/1.1.1 (;Samsung;SmartTV2012;;;) WebKit",
+        "expect"  :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "SmartTV2012",
+            "type"    : "smarttv"
+        }
+    },
+    {
+        "desc"    : "Samsung SmartTV2014",
+        "ua"      : "HbbTV/1.1.1 (;Samsung;SmartTV2014;T-NT14UDEUC-1060.4;;) WebKit",
+        "expect"  :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "SmartTV2014",
+            "type"    : "smarttv"
         }
     },
     {


### PR DESCRIPTION
SmartTVs which support HbbTV offer directly the vendor and model name:
`HbbTV/<version> (<capabilities>;<vendorName>;<modelName>;<softwareVersion>;<hardwareVersion>;<reserved>)`
