### PR TITLE
Fixed require sample in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ console.log('Server running at http://127.0.0.1:1337/');
 ### Using requirejs
 
 ```js
-require(['ua-parser'], function(UAParser) {
+require(['ua-parser-js'], function(UAParser) {
     var parser = new UAParser();
     console.log(parser.getResult());
 });


### PR DESCRIPTION
Module name is `ua-parser-js`, not `ua-parser` (see [here](https://github.com/faisalman/ua-parser-js/blob/d929c3e5087fd88083e8012d06fc2da013809757/src/ua-parser.js#L855))