### PR TITLE
Add generic device detection for samsung smartphones

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -560,7 +560,7 @@
             /android.+((sch-i[89]0\d|shw-m380s|gt-p\d{4}|gt-n8000|sgh-t8[56]9|nexus 10))/i,
             /((SM-T\w+))/i
             ], [[VENDOR, 'Samsung'], MODEL, [TYPE, TABLET]], [                  // Samsung
-            /((s[cgp]h-\w+|gt-\w+|galaxy\snexus|sm-n900))/i,
+            /((s[cgp]h-\w+|gt-\w+|galaxy\snexus|sm-\w[\w\d]+))/i,
             /(sam[sung]*)[\s-]*(\w+-?[\w-]*)*/i,
             /sec-((sgh\w+))/i
             ], [[VENDOR, 'Samsung'], MODEL, [TYPE, MOBILE]], [

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -268,5 +268,56 @@
             "model"   : "Galaxy Nexus",
             "type"    : "mobile"
         }
+    },
+    {
+        "desc"      : "Samsung Galaxy S5",
+        "ua"        : "Mozilla/5.0 (Linux; Android 5.0; SM-G900F Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36",
+        "expect"    :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "SM-G900F",
+            "type"    : "mobile"
+        }
+    },
+    {
+        "desc"    : "Samsung Galaxy S6",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.4.2; SM-G920I Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "SM-G920I",
+            "type"    : "mobile"
+        }
+    },
+    {
+        "desc"    : "Samsung Galaxy S6 Edge",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.4.2; SM-G925I Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "SM-G925I",
+            "type"    : "mobile"
+        }
+    },
+    {
+        "desc"    : "Samsung Galaxy Note 5 Chrome",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.1.1; SM-N920C Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "SM-N920C",
+            "type"    : "mobile"
+        }
+    }
+,
+    {
+        "desc"    : "Samsung Galaxy Note 5 Samsung Browser",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-N920C Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Samsung",
+            "model"   : "SM-N920C",
+            "type"    : "mobile"
+        }
     }
 ]


### PR DESCRIPTION
Hello,

since Samsung is throwing out so many smartphones that a real device detection is probably really hard to implement, I changed the current detection to be more generic and at least return the model name correctly. This also incorporates #126 (partly) and #142, but obviously doesn't return the pretty name like "Galaxy S5".
Furthermore I noticed that the user agent string of my note 5 differs on the device port when I use the samsung browser instead of chrome. I added a test for both cases.

Let me know what you think :smile: 
Best Regards,
Ben
