### PR TITLE
rewrote license field to be SPDX compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,16 +70,7 @@
     "type": "git",
     "url": "https://github.com/faisalman/ua-parser-js.git"
   },
-  "licenses": [
-    {
-      "type": "GPLv2",
-      "url": "http://www.gnu.org/licenses/gpl-2.0.html"
-    },
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "(GPL-2.0 OR MIT)",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
According to [NPM docs](https://docs.npmjs.com/files/package.json#license) the `license` field in package.json should be SPDX compatible.

[SPDX](https://spdx.org/licenses/) is a format which allows you to specify your licenses in an easy understandable, machine parseable way.

These changes reflect your license choice according to #1