### PR TITLE
Use an SPDX license expression in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,16 +70,7 @@
     "type": "git",
     "url": "https://github.com/faisalman/ua-parser-js.git"
   },
-  "licenses": [
-    {
-      "type": "GPLv2",
-      "url": "http://www.gnu.org/licenses/gpl-2.0.html"
-    },
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "(MIT OR GPL-2.0)",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
From https://docs.npmjs.com/files/package.json#license:

> Some old packages used license objects or a "licenses" property
> containing an array of license objects

This replaces that, as per:

> If your package is licensed under multiple common licenses, use an
> SPDX license expression syntax version 2.0 string

See https://npmjs.com/package/spdx for more context