### PR TITLE
Fix: don't define the RequireJs module with name

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -862,7 +862,7 @@
     } else {
         // requirejs env (optional)
         if (typeof(define) === FUNC_TYPE && define.amd) {
-            define("ua-parser-js", [], function () {
+            define(function () {
                 return UAParser;
             });
         } else {


### PR DESCRIPTION
If we define it with name it becomes less portable and breaks code that used version `0.7.10`.
This is **not correct according to semver**, as this is a `patch` only which should not break APIs.

I think defining the module with a name should be a responsibility of build tools / optimisation tools.

If there was a reason behind the change, please let me know, however even if the change is justified it should go out with a new major version IMO.

@faisalman