### PR TITLE
Fix browser name of Firefox on iOS

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -303,7 +303,7 @@
             ], [VERSION, [NAME, 'Facebook']], [
 
             /fxios\/([\w\.-]+)/i                                                // Firefox for iOS
-            ], [VERSION, [NAME, 'Firefox']], [
+        ], [VERSION, [NAME, 'iOS Firefox']], [
 
             /version\/([\w\.]+).+?mobile\/\w+\s(safari)/i                       // Mobile Safari
             ], [VERSION, [NAME, 'Mobile Safari']], [

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -834,9 +834,19 @@
         "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) FxiOS/1.1 Mobile/13B143 Safari/601.1.46",
         "expect"  :
         {
-            "name"    : "Firefox",
+            "name"    : "iOS Firefox",
             "version" : "1.1",
             "major"   : "1"
+        }
+    },
+    {
+        "desc"    : "Firefox iOS on iPad",
+        "ua"      : "Mozilla/5.0 (iPad; CPU OS 10_0_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) FxiOS/5.3 Mobile/14A456 Safari/602.1.50",
+        "expect"  :
+        {
+            "name"    : "iOS Firefox",
+            "version" : "5.3",
+            "major"   : "5"
         }
     }
 ]


### PR DESCRIPTION
Hi!

We use your module in production and faced an issue when we need to reject **only** desktop Firefox browsers with **< 30** versions.

But since versions of Firefox for iOS are different than for desktops, here is a problem - all iOS mobile users are being rejected because the latest version of Firefox on iOS is **5** which is obviously less than **30**.

So the proposed change basically helps differentiate Firefox on iOS.