### PR TITLE
Added Multiple Tablets Detection (LG, RCA, Dell, Verizon, etc.)

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -606,7 +606,8 @@
             /(lg) netcast\.tv/i                                                 // LG SmartTV
             ], [VENDOR, MODEL, [TYPE, SMARTTV]], [
             /(nexus\s[45])/i,                                                   // LG
-            /lg[e;\s\/-]+(\w+)*/i
+            /lg[e;\s\/-]+(\w+)*/i,
+            /android.+lg(\-?[\d\w]+)\s+build/i
             ], [MODEL, [VENDOR, 'LG'], [TYPE, MOBILE]], [
 
             /android.+(ideatab[a-z0-9\-\s]+)/i                                  // Lenovo

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -651,6 +651,8 @@
             /android.+[;\/]\s+(Barnes[&\s]+Noble\s+|BN[RT])(V?.*)\s+build/i     // Barnes & Noble Tablet
             ], [[VENDOR, 'Barnes & Noble'], MODEL, [TYPE, TABLET]], [
 
+            /android.+[;\/]\s+(TM\d{3}.*\b)\s+build/i                           // Barnes & Noble Tablet
+            ], [MODEL, [VENDOR, 'NuVision'], [TYPE, TABLET]], [
 
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -673,6 +673,9 @@
             /android.+[;\/]\s*(NS-?.+)\s+build/i                                // Insignia Tablets
             ], [MODEL, [VENDOR, 'Insignia'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*((NX|Next)-?.+)\s+build/i                         // NextBook Tablets
+            ], [MODEL, [VENDOR, 'NextBook'], [TYPE, TABLET]], [
+
             /android.+[;\/]\s*(Xtreme\_?)?(V(1[045]|2[015]|30|40|60|7[05]|90))\s+build/i
             ], [[VENDOR, 'Voice'], MODEL, [TYPE, MOBILE]], [                    // Voice Xtreme Phones
 

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -697,6 +697,9 @@
             /android.+[;\/]\s*TU_(1491)\s+build/i                               // Rotor Tablets
             ], [MODEL, [VENDOR, 'Rotor'], [TYPE, TABLET]], [
 
+            /android.+(KS(.+))\s+build/i                                        // Amazon Kindle Tablets
+            ], [MODEL, [VENDOR, 'Amazon'], [TYPE, TABLET]], [
+
             /\s(tablet|tab)[;\/]/i,                                             // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -666,6 +666,10 @@
             /android.+[;\/]\s*((Zeki)?TB.*\b)\s+build/i                         // Zeki Tablets
             ], [MODEL, [VENDOR, 'Zeki'], [TYPE, TABLET]], [
 
+            /(android).+[;\/]\s+([YR]\d{2}x?.*)\s+build/i,
+            /android.+[;\/]\s+(Dragon[\-\s]+Touch\s+|DT)(.+)\s+build/i          // Dragon Touch Tablet
+            ], [[VENDOR, 'Dragon Touch'], MODEL, [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -654,6 +654,9 @@
             /android.+[;\/]\s+(TM\d{3}.*\b)\s+build/i                           // Barnes & Noble Tablet
             ], [MODEL, [VENDOR, 'NuVision'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(zte)?.+(k\d{2})\s+build/i                        // ZTE K Series Tablet
+            ], [[VENDOR, 'ZTE'], MODEL, [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL]

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -659,9 +659,13 @@
 
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
-            ], [[TYPE, util.lowerize], VENDOR, MODEL]
+            ], [[TYPE, util.lowerize], VENDOR, MODEL], [
 
-            /*//////////////////////////
+            /(android.+)[;\/].+build/i                                          // Generic Android Device
+            ], [MODEL, [VENDOR, 'Generic']]
+
+
+        /*//////////////////////////
             // TODO: move to string map
             ////////////////////////////
 

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -685,6 +685,9 @@
             /android.+[;\/]\s*(Trio[\s\-]*.*)\s+build/i                         // MachSpeed Tablets
             ], [MODEL, [VENDOR, 'MachSpeed'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(Trinity)[\-\s]*(T\d{3})\s+build/i                // Trinity Tablets
+            ], [VENDOR, MODEL, [TYPE, TABLET]], [
+
             /android.+[;\/]\s*TU_(1491)\s+build/i                               // Rotor Tablets
             ], [MODEL, [VENDOR, 'Rotor'], [TYPE, TABLET]], [
 

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -648,6 +648,9 @@
             /android.+[;\/]\s*(Q[T|M][\d\w]+)\s+build/i                         // Verizon Tablet
             ], [MODEL, [VENDOR, 'Verizon'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s+(Barnes[&\s]+Noble\s+|BN[RT])(V?.*)\s+build/i     // Barnes & Noble Tablet
+            ], [[VENDOR, 'Barnes & Noble'], MODEL, [TYPE, TABLET]], [
+
 
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -599,6 +599,8 @@
             /android\s3\.[\s\w;-]{10}(a\d{3})/i                                 // Acer
             ], [MODEL, [VENDOR, 'Acer'], [TYPE, TABLET]], [
 
+            /android.+([vl]k\-?\d{3})\s+build/i                                 // LG Tablet
+            ], [MODEL, [VENDOR, 'LG'], [TYPE, TABLET]], [
             /android\s3\.[\s\w;-]{10}(lg?)-([06cv9]{3,4})/i                     // LG Tablet
             ], [[VENDOR, 'LG'], MODEL, [TYPE, TABLET]], [
             /(lg) netcast\.tv/i                                                 // LG SmartTV

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -691,7 +691,7 @@
             /android.+[;\/]\s*TU_(1491)\s+build/i                               // Rotor Tablets
             ], [MODEL, [VENDOR, 'Rotor'], [TYPE, TABLET]], [
 
-            /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
+            /\s(tablet|tab)[;\/]/i,                                             // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [
 

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -679,6 +679,9 @@
             /android.+[;\/]\s*(LVTEL\-?)?(V1[12])\s+build/i                     // LvTel Phones
             ], [[VENDOR, 'LvTel'], MODEL, [TYPE, MOBILE]], [
 
+            /android.+[;\/]\s*(V(100MD|700NA|7011|917G).*\b)\s+build/i          // Envizen Tablets
+            ], [MODEL, [VENDOR, 'Envizen'], [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -639,6 +639,9 @@
             /android.+a000(1)\s+build/i                                         // OnePlus
             ], [MODEL, [VENDOR, 'OnePlus'], [TYPE, MOBILE]], [
 
+            /android.+[;\/]\s*(RCT[\d\w]+)\s+build/i                            // RCA Tablets
+            ], [MODEL, [VENDOR, 'RCA'], [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL]

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -673,6 +673,9 @@
             /android.+[;\/]\s*(NS-?.+)\s+build/i                                // Insignia Tablets
             ], [MODEL, [VENDOR, 'Insignia'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(Xtreme\_?)?(V(1[045]|2[015]|30|40|60|7[05]|90))\s+build/i
+            ], [[VENDOR, 'Voice'], MODEL, [TYPE, MOBILE]], [                    // Voice Xtreme Phones
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -700,6 +700,9 @@
             /android.+(KS(.+))\s+build/i                                        // Amazon Kindle Tablets
             ], [MODEL, [VENDOR, 'Amazon'], [TYPE, TABLET]], [
 
+            /android.+(Gigaset)[\s\-]+(Q.+)\s+build/i                           // Gigaset Tablets
+            ], [VENDOR, MODEL, [TYPE, TABLET]], [
+
             /\s(tablet|tab)[;\/]/i,                                             // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -670,6 +670,9 @@
             /android.+[;\/]\s+(Dragon[\-\s]+Touch\s+|DT)(.+)\s+build/i          // Dragon Touch Tablet
             ], [[VENDOR, 'Dragon Touch'], MODEL, [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(NS-?.+)\s+build/i                                // Insignia Tablets
+            ], [MODEL, [VENDOR, 'Insignia'], [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -663,6 +663,9 @@
             /android.+[;\/]\s*(zur\d{3})\s+build/i                              // Swiss ZUR Tablet
             ], [MODEL, [VENDOR, 'Swiss'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*((Zeki)?TB.*\b)\s+build/i                         // Zeki Tablets
+            ], [MODEL, [VENDOR, 'Zeki'], [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -685,6 +685,9 @@
             /android.+[;\/]\s*(V(100MD|700NA|7011|917G).*\b)\s+build/i          // Envizen Tablets
             ], [MODEL, [VENDOR, 'Envizen'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(Le[\s\-]+Pan)[\s\-]+(.*\b)\s+build/i             // Le Pan Tablets
+            ], [VENDOR, MODEL, [TYPE, TABLET]], [
+
             /android.+[;\/]\s*(Trio[\s\-]*.*)\s+build/i                         // MachSpeed Tablets
             ], [MODEL, [VENDOR, 'MachSpeed'], [TYPE, TABLET]], [
 

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -676,6 +676,9 @@
             /android.+[;\/]\s*(Xtreme\_?)?(V(1[045]|2[015]|30|40|60|7[05]|90))\s+build/i
             ], [[VENDOR, 'Voice'], MODEL, [TYPE, MOBILE]], [                    // Voice Xtreme Phones
 
+            /android.+[;\/]\s*(LVTEL\-?)?(V1[12])\s+build/i                     // LvTel Phones
+            ], [[VENDOR, 'LvTel'], MODEL, [TYPE, MOBILE]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -682,6 +682,9 @@
             /android.+[;\/]\s*(V(100MD|700NA|7011|917G).*\b)\s+build/i          // Envizen Tablets
             ], [MODEL, [VENDOR, 'Envizen'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*TU_(1491)\s+build/i                               // Rotor Tablets
+            ], [MODEL, [VENDOR, 'Rotor'], [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -682,6 +682,9 @@
             /android.+[;\/]\s*(V(100MD|700NA|7011|917G).*\b)\s+build/i          // Envizen Tablets
             ], [MODEL, [VENDOR, 'Envizen'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(Trio[\s\-]*.*)\s+build/i                         // MachSpeed Tablets
+            ], [MODEL, [VENDOR, 'MachSpeed'], [TYPE, TABLET]], [
+
             /android.+[;\/]\s*TU_(1491)\s+build/i                               // Rotor Tablets
             ], [MODEL, [VENDOR, 'Rotor'], [TYPE, TABLET]], [
 

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -642,8 +642,12 @@
             /android.+[;\/]\s*(RCT[\d\w]+)\s+build/i                            // RCA Tablets
             ], [MODEL, [VENDOR, 'RCA'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(Venue[\d\s]*)\s+build/i                          // Dell Venue Tablets
+            ], [MODEL, [VENDOR, 'Dell'], [TYPE, TABLET]], [
+
             /android.+[;\/]\s*(Q[T|M][\d\w]+)\s+build/i                         // Verizon Tablet
             ], [MODEL, [VENDOR, 'Verizon'], [TYPE, TABLET]], [
+
 
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -642,6 +642,9 @@
             /android.+[;\/]\s*(RCT[\d\w]+)\s+build/i                            // RCA Tablets
             ], [MODEL, [VENDOR, 'RCA'], [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(Q[T|M][\d\w]+)\s+build/i                         // Verizon Tablet
+            ], [MODEL, [VENDOR, 'Verizon'], [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL]

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -657,6 +657,12 @@
             /android.+[;\/]\s*(zte)?.+(k\d{2})\s+build/i                        // ZTE K Series Tablet
             ], [[VENDOR, 'ZTE'], MODEL, [TYPE, TABLET]], [
 
+            /android.+[;\/]\s*(gen\d{3})\s+build.*49h/i                         // Swiss GEN Mobile
+            ], [MODEL, [VENDOR, 'Swiss'], [TYPE, MOBILE]], [
+
+            /android.+[;\/]\s*(zur\d{3})\s+build/i                              // Swiss ZUR Tablet
+            ], [MODEL, [VENDOR, 'Swiss'], [TYPE, TABLET]], [
+
             /\s(tablet)[;\/]/i,                                                 // Unidentifiable Tablet
             /\s(mobile)(?:[;\/]|\ssafari)/i                                     // Unidentifiable Mobile
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -710,4 +710,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Dragon Touch Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.0.4; DT9138B Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Dragon Touch",
+            "model"   : "9138B",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -798,4 +798,26 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "NextBook Next7",
+        "ua"      : "Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Next7P12 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30",
+        "expect"  :
+        {
+            "vendor"  : "NextBook",
+            "model"   : "Next7P12",
+            "type"    : "tablet"
+        }
+    }
+,
+    {
+        "desc"    : "NextBook Tablets",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.0; NXA8QC116 Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "NextBook",
+            "model"   : "NXA8QC116",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -732,4 +732,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Voice Xtreme V75",
+        "ua"      : "Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; V75 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+        "expect"  :
+        {
+            "vendor"  : "Voice",
+            "model"   : "V75",
+            "type"    : "mobile"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -677,4 +677,26 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Swizz GEN610",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.4.2; GEN610 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Swiss",
+            "model"   : "GEN610",
+            "type"    : "mobile"
+        }
+    }
+,
+    {
+        "desc"    : "Swizz ZUR700",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.4.2; ZUR700 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Swiss",
+            "model"   : "ZUR700",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -853,4 +853,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Gigaset Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.2.2; Gigaset QV830 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Gigaset",
+            "model"   : "QV830",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -787,4 +787,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Trinity Tablets",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.0.1; Trinity T101 Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Trinity",
+            "model"   : "T101",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -765,4 +765,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Rotor Tablet",
+        "ua"      : "mozilla/5.0 (linux; android 5.0.1; tu_1491 build/lrx22c) applewebkit/537.36 (khtml, like gecko) chrome/43.0.2357.93 safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Rotor",
+            "model"   : "1491",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -712,12 +712,23 @@
     }
 ,
     {
-        "desc"    : "Dragon Touch Tablet",
-        "ua"      : "Mozilla/5.0 (Linux; Android 4.0.4; DT9138B Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36",
+    "desc"    : "Dragon Touch Tablet",
+    "ua"      : "Mozilla/5.0 (Linux; Android 4.0.4; DT9138B Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36",
+    "expect"  :
+    {
+    "vendor"  : "Dragon Touch",
+    "model"   : "9138B",
+    "type"    : "tablet"
+    }
+    }
+,
+    {
+        "desc"    : "Insignia Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; U; Android 6.0.1; NS-P08A7100 Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Safari/537.36",
         "expect"  :
         {
-            "vendor"  : "Dragon Touch",
-            "model"   : "9138B",
+            "vendor"  : "Insignia",
+            "model"   : "NS-P08A7100",
             "type"    : "tablet"
         }
     }

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -622,4 +622,26 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Barnes & Noble Nook HD+ Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Barnes & Noble Nook HD+ Build/JZO54K; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+        "expect"  :
+        {
+            "vendor"  : "Barnes & Noble",
+            "model"   : "Nook HD+",
+            "type"    : "tablet"
+        }
+    }
+,
+    {
+        "desc"    : "Barnes & Noble V400 Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.0.4; BNTV400 Build/IMM76L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Barnes & Noble",
+            "model"   : "V400",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -699,4 +699,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Zeki TB782b Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; TB782B Build/IMM76D) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.2.299 U3/0.8.0 Mobile Safari/534.31",
+        "expect"  :
+        {
+            "vendor"  : "Zeki",
+            "model"   : "TB782B",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -655,4 +655,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "ZTE K Series Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 6.0.1; K88 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "ZTE",
+            "model"   : "K88",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -524,6 +524,17 @@
         }
     }
 ,
+
+    {
+        "desc"    : "Generic Android Device",
+        "ua"      : "Mozilla/5.0  (Linux; U; Android 6.0.1; i980 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Generic",
+            "model"   : "Android 6.0.1"
+        }
+    }
+,
     {
         "desc"    : "LG VK Series Tablet",
         "ua"      : "Mozilla/5.0 (Linux; Android 5.0.2; VK700 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.84 Safari/537.36",

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -644,4 +644,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "NuVision TM101A540N Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.1; TM101A540N Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "NuVision",
+            "model"   : "TM101A540N",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -600,4 +600,26 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Dell Venue 8 Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.4.2; Venue 8 3830 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Dell",
+            "model"   : "Venue 8 3830",
+            "type"    : "tablet"
+        }
+    }
+,
+    {
+        "desc"    : "Dell Venue 7 Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.4.2; Venue 7 3730 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Dell",
+            "model"   : "Venue 7 3730",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -820,4 +820,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Le Pan Tablets",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.2.2; Le Pan TC802A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Le Pan",
+            "model"   : "TC802A",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -523,4 +523,26 @@
             "type"    : "mobile"
         }
     }
+,
+    {
+        "desc"    : "LG VK Series Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.0.2; VK700 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.84 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "LG",
+            "model"   : "VK700",
+            "type"    : "tablet"
+        }
+    }
+,
+    {
+        "desc"    : "LG LK Series Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.0.1; LGLK430 Build/LRX21Y) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "LG",
+            "model"   : "LK430",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -776,4 +776,15 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "MachSpeed Tablets",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.4.2; Trio 7.85 vQ Build/Trio_7.85_vQ) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "MachSpeed",
+            "model"   : "Trio 7.85 vQ",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -831,4 +831,26 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Le Pan Tablets",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.2.2; Le Pan TC802A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Le Pan",
+            "model"   : "TC802A",
+            "type"    : "tablet"
+        }
+    }
+,
+    {
+        "desc"    : "Amazon Kindle Fire Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; U; Android 4.4.3; en-us; KFSAWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.66 like Chrome/39.0.2171.93 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Amazon",
+            "model"   : "KFSAWI",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -754,4 +754,15 @@
             "type"    : "mobile"
         }
     }
+,
+    {
+        "desc"    : "Envizen Tablet V100MD",
+        "ua"      : "Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; V100MD Build/V100MD.20130816) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30",
+        "expect"  :
+        {
+            "vendor"  : "Envizen",
+            "model"   : "V100MD",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -545,4 +545,26 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "RCA Voyager III Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 6.0.1; RCT6973W43 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "RCA",
+            "model"   : "RCT6973W43",
+            "type"    : "tablet"
+        }
+    }
+,
+    {
+        "desc"    : "RCA Voyager II Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.0; RCT6773W22B Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "RCA",
+            "model"   : "RCT6773W22B",
+            "type"    : "tablet"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -743,4 +743,15 @@
             "type"    : "mobile"
         }
     }
+,
+    {
+        "desc"    : "LvTel V11",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.1.1; V11 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "LvTel",
+            "model"   : "V11",
+            "type"    : "mobile"
+        }
+    }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -567,4 +567,37 @@
             "type"    : "tablet"
         }
     }
+,
+    {
+        "desc"    : "Verizon Quanta Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 4.4.2; QMV7B Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Verizon",
+            "model"   : "QMV7B",
+            "type"    : "tablet"
+        }
+    }
+,
+    {
+        "desc"    : "Verizon Ellipsis 8 Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 5.1.1; QTAQZ3 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Verizon",
+            "model"   : "QTAQZ3",
+            "type"    : "tablet"
+        }
+    }
+,
+    {
+        "desc"    : "Verizon Ellipsis 8HD Tablet",
+        "ua"      : "Mozilla/5.0 (Linux; Android 6.0.1; QTASUN1 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36",
+        "expect"  :
+        {
+            "vendor"  : "Verizon",
+            "model"   : "QTASUN1",
+            "type"    : "tablet"
+        }
+    }
 ]


### PR DESCRIPTION
Hi,

I have added the detection for following devices, (source of UAStrings --> www.handsetdetection.com )

- LG Tablets (VK, LK Series)
- RCA Tablets
- Dell Venue Tablets
- Verizon Tablets
- Barnes & Noble Tablets
- NuVision Tablets
- Swiss Mobiles & Tablets
- Zeki Tablets
- Dragon Touch Tablets
- Insignia Tablets

Will add more, in upcoming commits
Also, I added a generic android device as a fallback for Android based User-Agent Strings.
@faisalman  please have a look


