### PR TITLE
Fix server side rendering

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -885,7 +885,7 @@
             define(function () {
                 return UAParser;
             });
-        } else {
+        } else if (window) {
             // browser env
             window.UAParser = UAParser;
         }
@@ -896,7 +896,7 @@
     //   In AMD env the global scope should be kept clean, but jQuery is an exception.
     //   jQuery always exports to global scope, unless jQuery.noConflict(true) is used,
     //   and we should catch that.
-    var $ = window.jQuery || window.Zepto;
+    var $ = window && (window.jQuery || window.Zepto);
     if (typeof $ !== UNDEF_TYPE) {
         var parser = new UAParser();
         $.ua = parser.getResult();


### PR DESCRIPTION
In server side rendering, the passed `window` parameter is `undefined` as the `this` in last line call gets compiled from something like:

```javascript
(typeof window === 'object' ? window : this)
```

to:
```javascript
(typeof window === 'object' ? window : undefined);
```

Thus `window.*` fail. This pull request fixes that problem.
