### PR TITLE
Facebook browser now recognized as well (not only iOS)

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -289,6 +289,9 @@
             /xiaomi\/miuibrowser\/([\w\.]+)/i                                   // MIUI Browser
             ], [VERSION, [NAME, 'MIUI Browser']], [
 
+            /;fbav\/([\w\.]+);/i                                                // Facebook App for iOS & Android
+            ], [VERSION, [NAME, 'Facebook']], [
+
             /(headlesschrome) ([\w\.]+)/i                                       // Chrome Headless
             ], [VERSION, [NAME, 'Chrome Headless']], [
 
@@ -311,9 +314,6 @@
 
             /(coast)\/([\w\.]+)/i                                               // Opera Coast
             ], [[NAME, 'Opera Coast'], VERSION], [
-
-            /;fbav\/([\w\.]+);/i                                                // Facebook App for iOS
-            ], [VERSION, [NAME, 'Facebook']], [
 
             /fxios\/([\w\.-]+)/i                                                // Firefox for iOS
             ], [VERSION, [NAME, 'Firefox']], [

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -230,13 +230,23 @@
         }
     },
     {
-        "desc"    : "Facebook in-App Browser",
+        "desc"    : "Facebook in-App Browser for Android",
         "ua"      : "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/35.0.0.48.273;]",
         "expect"  :
         {
-            "name"    : "Chrome WebView",
-            "version" : "43.0.2357.121",
-            "major"   : "43"
+            "name"    : "Facebook",
+            "version" : "35.0.0.48.273",
+            "major"   : "35"
+        }
+    },
+    {
+        "desc"    : "Facebook in-App Browser for iOS",
+        "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E304 [FBAN/FBIOS;FBAV/91.0.0.41.73;FBBV/57050710;FBDV/iPhone8,1;FBMD/iPhone;FBSN/iOS;FBSV/10.3.1;FBSS/2;FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBOP/5;FBRV/0])",
+        "expect"  :
+        {
+            "name"    : "Facebook",
+            "version" : "91.0.0.41.73",
+            "major"   : "91"
         }
     },
     {


### PR DESCRIPTION
Hi Faisalman,

As proposed by you, here is the PR.
I actually didn't have to 'add' a new recognition, instead I had to move the Facebook Browser regex a bit up, since the Chrome Web View was identified first, before the Facebook regex could analyze the UA.

Based on the change I updated the current test for the Facebook browser for Android as well as adding a new iOS test for Facebook => all green now.

Let me know if I forgot anything. 

KR,
ebbmo