### PR TITLE
Detect "Chrome Mobile" & "Firefox Mobile"

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -293,7 +293,7 @@
             ], [VERSION, [NAME, 'Chrome Headless']], [
 
             /\swv\).+(chrome)\/([\w\.]+)/i                                      // Chrome WebView
-            ], [[NAME, /(.+)/, '$1 WebView'], VERSION], [
+            ], [[NAME, 'Chrome WebView'], VERSION], [
 
             /((?:oculus|samsung)browser)\/([\w\.]+)/i
             ], [[NAME, /(.+(?:g|us))(.+)/, '$1 $2'], VERSION], [                // Oculus / Samsung Browser
@@ -301,8 +301,13 @@
             /android.+version\/([\w\.]+)\s+(?:mobile\s?safari|safari)*/i        // Android Browser
             ], [VERSION, [NAME, 'Android Browser']], [
 
-            /(chrome|omniweb|arora|[tizenoka]{5}\s?browser)\/v?([\w\.]+)/i
-                                                                                // Chrome/OmniWeb/Arora/Tizen/Nokia
+            /(omniweb|arora|[tizenoka]{5}\s?browser)\/v?([\w\.]+)/i             // OmniWeb/Arora/Tizen/Nokia
+            ], [NAME, VERSION], [
+
+            /(chrome)\/([\w\.]+) Mobile/i                                      // Chrome Mobile
+            ], [[NAME, 'Chrome Mobile'], VERSION], [
+
+            /(chrome)\/v?([\w\.]+)/i                                      // Chrome
             ], [NAME, VERSION], [
 
             /(dolfin)\/([\w\.]+)/i                                              // Dolphin
@@ -314,8 +319,11 @@
             /(coast)\/([\w\.]+)/i                                               // Opera Coast
             ], [[NAME, 'Opera Coast'], VERSION], [
 
+            /(?:mobile|tablet);.*(firefox)\/([\w\.-]+)/i                        // Firefox Mobile
+            ], [[NAME, 'Firefox Mobile'], VERSION], [
+
             /fxios\/([\w\.-]+)/i                                                // Firefox for iOS
-            ], [VERSION, [NAME, 'Firefox']], [
+            ], [VERSION, [NAME, 'Firefox Mobile']], [
 
             /version\/([\w\.]+).+?mobile\/\w+\s(safari)/i                       // Mobile Safari
             ], [VERSION, [NAME, 'Mobile Safari']], [

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -934,9 +934,39 @@
         "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) FxiOS/1.1 Mobile/13B143 Safari/601.1.46",
         "expect"  :
         {
-            "name"    : "Firefox",
+            "name"    : "Firefox Mobile",
             "version" : "1.1",
             "major"   : "1"
+        }
+    },
+    {
+        "desc"    : "Chrome Mobile",
+        "ua"      : "Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "Chrome Mobile",
+            "version" : "58.0.3029.83",
+            "major"   : "58"
+        }
+    },
+    {
+        "desc"    : "Firefox Mobile",
+        "ua"      : "Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47W) AppleWebKit/537.36 (KHTML, like Gecko) FxiOS/7.5b3349 Mobile/14F89 Safari/603.2.4",
+        "expect"  :
+        {
+            "name"    : "Firefox Mobile",
+            "version" : "7.5b3349",
+            "major"   : "7"
+        }
+    },
+    {
+        "desc"    : "Firefox Mobile",
+        "ua"      : "Mozilla/5.0 (Android 5.0; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0",
+        "expect"  :
+        {
+            "name"    : "Firefox Mobile",
+            "version" : "41.0",
+            "major"   : "41"
         }
     }
 ]


### PR DESCRIPTION
Fixes #248 

Breaking Change: Firefox on iOS will now be detected as "Firefox Mobile" and not "Firefox"