### PR TITLE
Roku Support

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -732,7 +732,10 @@
             ], [[TYPE, util.lowerize], VENDOR, MODEL], [
 
             /(android.+)[;\/].+build/i                                          // Generic Android Device
-            ], [MODEL, [VENDOR, 'Generic']]
+            ], [MODEL, [VENDOR, 'Generic']],[
+
+            /roku\/dvp\-.*\s\((\d{2}).*\)/i                                     // Roku
+            ], [MODEL, [VENDOR, 'Roku'], [TYPE, SMARTTV]]
 
 
         /*//////////////////////////
@@ -871,7 +874,10 @@
             /(plan\s9|minix|beos|os\/2|amigaos|morphos|risc\sos|openvms)/i,
                                                                                 // Plan9/Minix/BeOS/OS2/AmigaOS/MorphOS/RISCOS/OpenVMS
             /(unix)\s?([\w\.]+)*/i                                              // UNIX
-            ], [NAME, VERSION]
+            ], [NAME, VERSION],[
+
+            /roku\/dvp\-(.*)\s/i                                                // Roku
+            ], [VERSION, [NAME, 'Roku']]
         ]
     };
 

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -815,5 +815,14 @@
             "model": "MI PAD 2",
             "type": "tablet"
         }
+    },
+    {
+        "desc": "Roku Digital Video Player",
+        "ua": "Roku/DVP-5.0 (025.00E08043A)",
+        "expect": {
+            "vendor": "Roku",
+            "model": "02",
+            "type": "smarttv"
+        }
     }
 ]

--- a/test/os-test.json
+++ b/test/os-test.json
@@ -637,5 +637,14 @@
             "name"    : "Android",
             "version" : "4.2.1"
         }
+    },
+    {
+        "desc"    : "Roku Digital Video Player",
+        "ua"      : "Roku/DVP-5.0 (025.00E08043A)",
+        "expect"  :
+        {
+            "name"    : "Roku",
+            "version" : "5.0"
+        }
     }
 ]


### PR DESCRIPTION
I recently used your package to detect mobile and TV devices, buy saw Roku was missing. Since it is one of the most popular devices on the market I thought I would submit a PR for support for it.

Unfortunately, the user agent string does not signify the type of hardware it is. It only indicates the device generation so I placed that in `device.model`.

The generation versions can be seen with this chart, but there is no further information to get more granular on device to distinguish Roku Stick, Roku 3, Roku LT, etc.

https://en.wikipedia.org/wiki/Roku#Feature_comparison