### PR TITLE
mark license comment as important

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -1,4 +1,4 @@
-/**
+/*!
  * UAParser.js v0.7.17
  * Lightweight JavaScript-based User-Agent string parser
  * https://github.com/faisalman/ua-parser-js


### PR DESCRIPTION
most of the minifier has option that keeps the comment that begun with `/*!` by default.
so users can use this lib easier(less-config).