### PR TITLE
Incorrect browser name shows for Edge browser on mobile 

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -261,7 +261,7 @@
             /(trident).+rv[:\s]([\w\.]+).+like\sgecko/i                         // IE11
             ], [[NAME, 'IE'], VERSION], [
 
-            /(edge|edgeios|edgea)\/((\d+)?[\w\.]+)/i                            // Microsoft Edge
+            /(edge|edgios|edgea)\/((\d+)?[\w\.]+)/i                            // Microsoft Edge
             ], [NAME, VERSION], [
 
             /(yabrowser)\/([\w\.]+)/i                                           // Yandex

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -661,7 +661,8 @@
             /android.+;\s(m[1-5]\snote)\sbuild/i                                // Meizu Tablet
             ], [MODEL, [VENDOR, 'Meizu'], [TYPE, TABLET]], [
 
-            /android.+a000(1)\s+build/i                                         // OnePlus
+            /android.+a000(1)\s+build/i,                                        // OnePlus
+            /android.+oneplus\s(a\d{4})\s+build/i
             ], [MODEL, [VENDOR, 'OnePlus'], [TYPE, MOBILE]], [
 
             /android.+[;\/]\s*(RCT[\d\w]+)\s+build/i                            // RCA Tablets

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -261,7 +261,7 @@
             /(trident).+rv[:\s]([\w\.]+).+like\sgecko/i                         // IE11
             ], [[NAME, 'IE'], VERSION], [
 
-            /(edge)\/((\d+)?[\w\.]+)/i                                          // Microsoft Edge
+            /(edge|edgeios|edgea)\/((\d+)?[\w\.]+)/i                            // Microsoft Edge
             ], [NAME, VERSION], [
 
             /(yabrowser)\/([\w\.]+)/i                                           // Yandex

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -197,6 +197,15 @@
         }
     },
     {
+        "desc": "OnePlus 3",
+        "ua": "Mozilla/5.0 (Linux; Android 7.1.1; ONEPLUS A3000 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36",
+        "expect": {
+            "vendor": "OnePlus",
+            "model": "A3000",
+            "type": "mobile"
+        }
+    },
+    {
         "desc": "OPPO R7s",
         "ua": "Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; OPPO R7s Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/7.1 Mobile Safari/537.36",
         "expect": {


### PR DESCRIPTION
Issue: browser.name returns `Mobile Safari` for edge browsers on mobiles. This will fix that bug.

More info: 
on mobile browsers, `navigator.appVersion` will have `EdgA` for android and `EdgiOS` for ios. 
I have also attached the screenshots for reference
1. for iPhone: 
![img_2421](https://user-images.githubusercontent.com/1021966/38200264-4698769c-36b1-11e8-93df-e3e150c9fc56.jpg)

2. for Android
![1858591746910083898](https://user-images.githubusercontent.com/1021966/38200268-4d3f1bcc-36b1-11e8-88e0-57a0d272e9a4.jpg)

Fixes #306 