### PR TITLE
Detect Firefox Focus & Opera Touch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 npm-debug.log
+
 ### vim ###
 .*.s[a-w][a-z]
 *.un~
@@ -8,12 +9,16 @@ Session.vim
 *~
 .versions
 
+### editors ###
+.vscode
+.idea
+*.sublime-*
+
 ### OSX ###
 .DS_Store
 .AppleDouble
 .LSOverride
 Icon
-
 
 # Thumbnails
 ._*
@@ -21,4 +26,3 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
-.idea

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -261,7 +261,7 @@
             /(trident).+rv[:\s]([\w\.]+).+like\sgecko/i                         // IE11
             ], [[NAME, 'IE'], VERSION], [
 
-            /(edge|edgios|edgea)\/((\d+)?[\w\.]+)/i                             // Microsoft Edge
+            /(edge|edgios|edgea|edga)\/((\d+)?[\w\.]+)/i                        // Microsoft Edge
             ], [[NAME, 'Edge'], VERSION], [
 
             /(yabrowser)\/([\w\.]+)/i                                           // Yandex
@@ -270,8 +270,13 @@
             /(puffin)\/([\w\.]+)/i                                              // Puffin
             ], [[NAME, 'Puffin'], VERSION], [
 
-            /((?:[\s\/])uc?\s?browser|(?:juc.+)ucweb)[\/\s]?([\w\.]+)/i
-                                                                                // UCBrowser
+            /(focus)\/([\w\.]+)/i                                               // Firefox Focus
+            ], [[NAME, 'Firefox Focus'], VERSION], [
+
+            /(opt)\/([\w\.]+)/i                                                 // Opera Touch
+            ], [[NAME, 'Opera Touch'], VERSION], [
+
+            /((?:[\s\/])uc?\s?browser|(?:juc.+)ucweb)[\/\s]?([\w\.]+)/i         // UCBrowser
             ], [[NAME, 'UCBrowser'], VERSION], [
 
             /(comodo_dragon)\/([\w\.]+)/i                                       // Comodo Dragon

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -261,7 +261,7 @@
             /(trident).+rv[:\s]([\w\.]+).+like\sgecko/i                         // IE11
             ], [[NAME, 'IE'], VERSION], [
 
-            /(edge|edgios|edgea|edga)\/((\d+)?[\w\.]+)/i                        // Microsoft Edge
+            /(edge|edgios|edga)\/((\d+)?[\w\.]+)/i                              // Microsoft Edge
             ], [[NAME, 'Edge'], VERSION], [
 
             /(yabrowser)\/([\w\.]+)/i                                           // Yandex

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -320,6 +320,15 @@
         }
     },
     {
+        "desc": "Firefox Focus",
+        "ua": "Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/6.1.1 Chrome/68.0.3440.91 Mobile Safari/537.36",
+        "expect": {
+            "name": "Firefox Focus",
+            "version": "6.1.1",
+            "major": "6"
+        }
+    },
+    {
         "desc"    : "Flock",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.3) Gecko/2008100716 Firefox/3.0.3 Flock/2.0",
         "expect"  :
@@ -720,6 +729,16 @@
         }
     },
     {
+        "desc"    : "Opera Touch",
+        "ua"      : "Mozilla/5.0 (Linux; Android 7.0; Lenovo P2a42 Build/NRD90N) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36 OPT/1.10.33",
+        "expect"  :
+        {
+            "name"    : "Opera Touch",
+            "version" : "1.10.33",
+            "major"   : "1"
+        }
+    },
+    {
         "desc"    : "PhantomJS",
         "ua"      : "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.2 Safari/534.34",
         "expect"  :
@@ -977,6 +996,16 @@
             "name"    : "Edge",
             "version" : "12.0",
             "major"   : "12"
+        }
+    },
+    {
+        "desc"    : "Microsoft Edge",
+        "ua"      : "Mozilla/5.0 (Linux; Android 7.0; Lenovo P2a42 Build/NRD90N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.123 Mobile Safari/537.36 EdgA/42.0.0.2314",
+        "expect"  :
+        {
+            "name"    : "Edge",
+            "version" : "42.0.0.2314",
+            "major"   : "42"
         }
     },
     {


### PR DESCRIPTION
- New regexes added in order to detect [Firefox Focus](https://www.mozilla.org/en-US/firefox/mobile/#focus) & [Opera Touch](https://www.opera.com/mobile/touch)
- Microsoft Edge detection improved to correctly detect Edge on Android
- Updated `.gitignore` to ignore VSCode and/or Sublime settings; added `.npmrc` in order to prevent `package-lock.json` creation