### PR TITLE
Fix Pixel XL devices on Chrome 70

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -679,7 +679,7 @@
             /android.+;\s(pixel c)[\s)]/i                                       // Google Pixel C
             ], [MODEL, [VENDOR, 'Google'], [TYPE, TABLET]], [
 
-            /android.+;\s(pixel( [23])?( xl)?)\s/i                              // Google Pixel
+            /android.+;\s(pixel( [23])?( xl)?)[\s)]/i                              // Google Pixel
             ], [MODEL, [VENDOR, 'Google'], [TYPE, MOBILE]], [
 
             /android.+;\s(\w+)\s+build\/hm\1/i,                                 // Xiaomi Hongmi 'numeric' models

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -648,6 +648,15 @@
         }
     },
     {
+        "desc": "Google Pixel XL",
+        "ua": "Mozilla/5.0 (Linux; Android 9; Pixel XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36",
+        "expect": {
+            "vendor": "Google",
+            "model": "Pixel XL",
+            "type": "mobile"
+        }
+    },
+    {
         "desc": "Google Pixel 2",
         "ua": "Mozilla/5.0 (Linux; Android 8.1.0; Pixel 2 Build/OPM1.171019.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36",
         "expect": {
@@ -666,6 +675,15 @@
         }
     },
     {
+        "desc": "Google Pixel 2 XL",
+        "ua": "Mozilla/5.0 (Linux; Android 9; Pixel 2 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36",
+        "expect": {
+            "vendor": "Google",
+            "model": "Pixel 2 XL",
+            "type": "mobile"
+        }
+    },
+    {
         "desc": "Google Pixel 3",
         "ua": "Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36",
         "expect": {
@@ -677,6 +695,15 @@
     {
         "desc": "Google Pixel 3 XL",
         "ua": "Mozilla/5.0 (Linux; Android 9; Pixel 3 XL Build/PD1A.180720.030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36",
+        "expect": {
+            "vendor": "Google",
+            "model": "Pixel 3 XL",
+            "type": "mobile"
+        }
+    },
+    {
+        "desc": "Google Pixel 3 XL",
+        "ua": "Mozilla/5.0 (Linux; Android 9; Pixel 3 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36",
         "expect": {
             "vendor": "Google",
             "model": "Pixel 3 XL",


### PR DESCRIPTION
All Pixel XL devices were being matched with their non-XL counter parts (i.e. Pixel 3 XL -> Pixel 3, Pixel 2 XL -> Pixel 2, Pixel XL -> Pixel) in Chrome 70. This change will fix this issue such that all of the Pixel devices are correctly identified. 