### PR TITLE
Add Ghost webhook UA

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -309,7 +309,7 @@
             /(MetaSr)[\/\s]?([\w\.]+)/i                                         // SouGouBrowser
             ], [NAME], [
 
-            /(LBBROWSER)/i                                      // LieBao Browser
+            /(LBBROWSER)/i                                                      // LieBao Browser
             ], [NAME], [
 
             /xiaomi\/miuibrowser\/([\w\.]+)/i                                   // MIUI Browser
@@ -382,7 +382,8 @@
             /(links)\s\(([\w\.]+)/i,                                            // Links
             /(gobrowser)\/?([\w\.]*)/i,                                         // GoBrowser
             /(ice\s?browser)\/v?([\w\._]+)/i,                                   // ICE Browser
-            /(mosaic)[\/\s]([\w\.]+)/i                                          // Mosaic
+            /(mosaic)[\/\s]([\w\.]+)/i,                                         // Mosaic
+            /(ghost)[\/\s]([\w\.]+)/i                                           // Ghost Webhooks
             ], [NAME, VERSION]
 
             /* /////////////////////
@@ -837,7 +838,7 @@
             ], [[NAME, 'Blink']], [
 
             /(presto)\/([\w\.]+)/i,                                             // Presto
-            /(webkit|trident|netfront|netsurf|amaya|lynx|w3m|goanna)\/([\w\.]+)/i,     
+            /(webkit|trident|netfront|netsurf|amaya|lynx|w3m|goanna)\/([\w\.]+)/i,
                                                                                 // WebKit/Trident/NetFront/NetSurf/Amaya/Lynx/w3m/Goanna
             /(khtml|tasman|links)[\/\s]\(?([\w\.]+)/i,                          // KHTML/Tasman/Links
             /(icab)[\/\s]([23]\.[\d\.]+)/i                                      // iCab

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -1120,7 +1120,7 @@
         "expect"  :
         {
             "name"    : "BIDUBrowser",
-            "version" : "8.7", 
+            "version" : "8.7",
             "major"   : "8"
         }
     },
@@ -1152,6 +1152,26 @@
             "name"    : "Brave",
             "version" : "4.5.16",
             "major"   : "4"
+        }
+    },
+    {
+        "desc"    : "Ghost OSS",
+        "ua"      : "Ghost/2.12.0 (https://github.com/TryGhost/Ghost)",
+        "expect"  :
+        {
+            "name"    : "Ghost",
+            "version" : "2.12.0",
+            "major"   : "2"
+        }
+    },
+    {
+        "desc"    : "Ghost Pro",
+        "ua"      : "Ghost/2.13.1+moya (https://github.com/TryGhost/Ghost)",
+        "expect"  :
+        {
+            "name"    : "Ghost",
+            "version" : "2.13.1",
+            "major"   : "2"
         }
     }
 ]


### PR DESCRIPTION
This PR adds the UA used by the Ghost publishing platform for webhook calls.

Any feedback welcome.

Thanks,

Tim Birkett.  