### PR TITLE
FIX: When using as AMD module with RequireJS optimizer using a namespace

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -1083,7 +1083,7 @@
         exports.UAParser = UAParser;
     } else {
         // requirejs env (optional)
-        if (typeof(define) === FUNC_TYPE && define.amd) {
+        if (typeof(define) === 'function' && define.amd) {
             define(function () {
                 return UAParser;
             });


### PR DESCRIPTION
... it does not get packed correctly, because r.js optimizer matches
the exact line containing 'function' as a string. 
(See r.js@26506)

See detailed explanation on branch here: https://github.com/symunona/ua-parser-js/tree/rjs-fix-explain