### PR TITLE
Add Avast Secure Browser & AVG Secure Browser

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -273,6 +273,9 @@
             /(Avast)\/([\w\.]+)/i                                               // Avast Secure Browser
             ], [[NAME, 'Avast Secure Browser'], VERSION], [
 
+            /(AVG)\/([\w\.]+)/i                                                 // Avast Secure Browser
+            ], [[NAME, 'AVG Secure Browser'], VERSION], [
+
             /(puffin)\/([\w\.]+)/i                                              // Puffin
             ], [[NAME, 'Puffin'], VERSION], [
 

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -273,7 +273,7 @@
             /(Avast)\/([\w\.]+)/i                                               // Avast Secure Browser
             ], [[NAME, 'Avast Secure Browser'], VERSION], [
 
-            /(AVG)\/([\w\.]+)/i                                                 // Avast Secure Browser
+            /(AVG)\/([\w\.]+)/i                                                 // AVG Secure Browser
             ], [[NAME, 'AVG Secure Browser'], VERSION], [
 
             /(puffin)\/([\w\.]+)/i                                              // Puffin

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -270,6 +270,9 @@
             /(yabrowser)\/([\w\.]+)/i                                           // Yandex
             ], [[NAME, 'Yandex'], VERSION], [
 
+            /(Avast)\/([\w\.]+)/i                                               // Avast Secure Browser
+            ], [[NAME, 'Avast Secure Browser'], VERSION], [
+
             /(puffin)\/([\w\.]+)/i                                              // Puffin
             ], [[NAME, 'Puffin'], VERSION], [
 

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -80,6 +80,16 @@
         }
     },
     {
+        "desc"    : "Avast Secure Browser",
+        "ua"      : "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36 Avast/72.0.1174.122",
+        "expect"  :
+        {
+            "name"    : "Avast Secure Browser",
+            "version" : "72.0.1174.122",
+            "major"   : "72"
+        }
+    },
+    {
         "desc"    : "Baidu",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; baidubrowser 1.x)",
         "expect"  :

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -90,6 +90,16 @@
         }
     },
     {
+        "desc"    : "AVG Secure Browser",
+        "ua"      : "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36 AVG/72.0.719.123",
+        "expect"  :
+        {
+            "name"    : "AVG Secure Browser",
+            "version" : "72.0.719.123",
+            "major"   : "72"
+        }
+    },
+    {
         "desc"    : "Baidu",
         "ua"      : "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; baidubrowser 1.x)",
         "expect"  :


### PR DESCRIPTION
Avast Secure Browser is based on Chromium with extra security features
https://www.avast.com/secure-browser

AVG Secure Browser is based on Chromium with extra security features
https://www.avg.com/en-ww/secure-browser
