### PR TITLE
Fix license

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "type": "git",
     "url": "https://github.com/faisalman/ua-parser-js.git"
   },
-  "license": "(GPL-2.0 OR MIT)",
+  "license": "MIT",
   "engines": {
     "node": "*"
   },

--- a/readme.md
+++ b/readme.md
@@ -325,18 +325,18 @@ Do you use & like UAParser.js but you don’t find a way to show some love? If y
 
 # License
 
-Dual licensed under GPLv2 or MIT
+MIT License
 
-Copyright © 2012-2018 Faisal Salman <<f@faisalman.com>>
+Copyright (c) 2012-2019 Faisal Salman <<f@faisalman.com>>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of 
-this software and associated documentation files (the "Software"), to deal in 
-the Software without restriction, including without limitation the rights to use, 
-copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the 
-Software, and to permit persons to whom the Software is furnished to do so, 
-subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all 
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR


### PR DESCRIPTION
I've noticed that license that you declared in `license.md` does not match licenses declared in `package.json` and `readme.md`. 

Since licenses in `package.json` and `readme.me` are much older (3 and 2 years old) than `license.md` (8 months), I assumed that your intention was to keep MIT license. 

Keeping GPL and MIT at the same time is quite confusing. 