### PR TITLE
Use Chrome version for Blink version.

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -669,8 +669,8 @@
             /windows.+\sedge\/([\w\.]+)/i                                       // EdgeHTML
             ], [VERSION, [NAME, 'EdgeHTML']], [
 
-            /webkit\/537\.36.+chrome\/(?!27)/i                                  // Blink
-            ], [[NAME, 'Blink']], [
+            /webkit\/537\.36.+chrome\/(?!27)([\w\.]+)/i                                  // Blink
+            ], [VERSION, [NAME, 'Blink']], [
 
             /(presto)\/([\w\.]+)/i,                                             // Presto
             /(webkit|trident|netfront|netsurf|amaya|lynx|w3m|goanna)\/([\w\.]+)/i,     

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -669,7 +669,7 @@
             /windows.+\sedge\/([\w\.]+)/i                                       // EdgeHTML
             ], [VERSION, [NAME, 'EdgeHTML']], [
 
-            /webkit\/537\.36.+chrome\/(?!27)([\w\.]+)/i                                  // Blink
+            /webkit\/537\.36.+chrome\/(?!27)([\w\.]+)/i                         // Blink
             ], [VERSION, [NAME, 'Blink']], [
 
             /(presto)\/([\w\.]+)/i,                                             // Presto

--- a/test/engine-test.json
+++ b/test/engine-test.json
@@ -5,7 +5,7 @@
         "expect"  :
         {
             "name"    : "Blink",
-            "version" : "undefined"
+            "version" : "57.0.2987.146"
         }
     },
     {


### PR DESCRIPTION
Currently, no engine version is specified for Blink-based browsers. However, there is a Chrome/Chromium version provided right after the `Chrome/` in the regular expression. This PR incorporates that as the engine version.