### PR TITLE
Classify Apple TV and Chromecast as smart TVs.

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -418,7 +418,7 @@
             ], [MODEL, [VENDOR, 'Apple'], [TYPE, TABLET]], [
 
             /(apple\s{0,1}tv)/i                                                 // Apple TV
-            ], [[MODEL, 'Apple TV'], [VENDOR, 'Apple']], [
+            ], [[MODEL, 'Apple TV'], [VENDOR, 'Apple'], [TYPE, SMARTTV]], [
 
             /(archos)\s(gamepad2?)/i,                                           // Archos
             /(hp).+(touchpad)/i,                                                // HP TouchPad
@@ -558,7 +558,7 @@
             ], [VENDOR, MODEL, [TYPE, MOBILE]], [
 
             /crkey/i                                                            // Google Chromecast
-            ], [[MODEL, 'Chromecast'], [VENDOR, 'Google']], [
+            ], [[MODEL, 'Chromecast'], [VENDOR, 'Google'], [TYPE, SMARTTV]], [
 
             /android.+;\s(glass)\s\d/i                                          // Google Glass
             ], [MODEL, [VENDOR, 'Google'], [TYPE, WEARABLE]], [

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -635,7 +635,8 @@
         "ua": "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.84 Safari/537.36 CrKey/1.22.79313",
         "expect": {
             "vendor": "Google",
-            "model": "Chromecast"
+            "model": "Chromecast",
+            "type": "smarttv"
         }
     },
     {


### PR DESCRIPTION
Technically they're not TVs in and of themselves, but they're intended to be used displaying on TVs.