### PR TITLE
Add Baidu App detection

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -239,8 +239,9 @@
                                                                                 // Lunascape/Maxthon/Netfront/Jasmine/Blazer
 
             // Trident based
-            /(avant\s|iemobile|slim|baidu)(?:browser)?[\/\s]?([\w\.]*)/i,
-                                                                                // Avant/IEMobile/SlimBrowser/Baidu
+            /(avant\s|iemobile|slim)(?:browser)?[\/\s]?([\w\.]*)/i,
+                                                                                // Avant/IEMobile/SlimBrowser
+            /(bidubrowser|baidubrowser)[\/\s]?([\w\.]+)/i,                      // Baidu Browser
             /(?:ms|\()(ie)\s([\w\.]+)/i,                                        // Internet Explorer
 
             // Webkit/KHTML based
@@ -294,7 +295,7 @@
             /m?(qqbrowser)[\/\s]?([\w\.]+)/i                                    // QQBrowser
             ], [NAME, VERSION], [
 
-            /(BIDUBrowser)[\/\s]?([\w\.]+)/i                                    // Baidu Browser
+            /(baiduboxapp)[\/\s]?([\w\.]+)/i                                    // Baidu App
             ], [NAME, VERSION], [
 
             /(2345Explorer)[\/\s]?([\w\.]+)/i                                   // 2345 Browser

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -94,7 +94,7 @@
         "ua"      : "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; baidubrowser 1.x)",
         "expect"  :
         {
-            "name"    : "baidu",
+            "name"    : "baidubrowser",
             "version" : "1.x",
             "major"   : "1"
         }
@@ -1106,6 +1106,26 @@
             "name"    : "QQ",
             "version" : "6.5.8.2910",
             "major"   : "6"
+        }
+    },
+    {
+        "desc"    : "baidu app on iOS",
+        "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16C101 main%2F1.0 baiduboxapp/11.12.0.18 (Baidu; P2 12.1.2)",
+        "expect"  :
+        {
+            "name"    : "baiduboxapp",
+            "version" : "11.12.0.18",
+            "major"   : "11"
+        }
+    },
+    {
+        "desc"    : "baidu app on Android",
+        "ua"      : "Mozilla/5.0 (Linux; Android 8.1.0; BKK-AL10 Build/HONORBKK-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36 T7/11.11 baiduboxapp/11.11.0.0 (Baidu; P1 8.1.0)",
+        "expect"  :
+        {
+            "name"    : "baiduboxapp",
+            "version" : "11.11.0.0",
+            "major"   : "11"
         }
     },
     {


### PR DESCRIPTION
Baidu App is a popular search engine application, which has over 151 million DAU
[Baidu App](http://xbox.m.baidu.com/)
[Baidu App on Google Play](https://play.google.com/store/apps/details?id=com.baidu.searchbox&hl=en_US)

Besides, I have checked that none of the applications from Baidu company use single 'baidu' as their UA identification. To make sure the Baidu App detection works good, I changed the regexp of Baidu Browser.

Any feedback welcome.

Thanks.