### PR TITLE
Added Huawei P20 Pro and Huawei Mate P20 Pro Device Detection

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -490,7 +490,7 @@
             ], [MODEL, [VENDOR, 'HTC'], [TYPE, TABLET]], [
 
             /d\/huawei([\w\s-]+)[;\)]/i,
-            /(nexus\s6p|vog-l29|ane-lx1|eml-l29|lya-l09|clt-l29)/i              // Huawei
+            /(nexus\s6p|vog-l29|ane-lx1|eml-l29|lya-l09|clt-l29|lya-al00|lya-al10|lya-l0c|lya-l29|lya-tl00)/i   // Huawei
             ], [MODEL, [VENDOR, 'Huawei'], [TYPE, MOBILE]], [
 
             /android.+(bah2?-a?[lw]\d{2})/i                                     // Huawei MediaPad

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -490,7 +490,7 @@
             ], [MODEL, [VENDOR, 'HTC'], [TYPE, TABLET]], [
 
             /d\/huawei([\w\s-]+)[;\)]/i,
-            /(nexus\s6p|vog-l29|ane-lx1|eml-l29|lya-l09)/i                      // Huawei
+            /(nexus\s6p|vog-l29|ane-lx1|eml-l29|lya-l09|clt-l29)/i              // Huawei
             ], [MODEL, [VENDOR, 'Huawei'], [TYPE, MOBILE]], [
 
             /android.+(bah2?-a?[lw]\d{2})/i                                     // Huawei MediaPad

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -490,7 +490,7 @@
             ], [MODEL, [VENDOR, 'HTC'], [TYPE, TABLET]], [
 
             /d\/huawei([\w\s-]+)[;\)]/i,
-            /(nexus\s6p|vog-l29|ane-lx1|eml-l29)/i                              // Huawei
+            /(nexus\s6p|vog-l29|ane-lx1|eml-l29|lya-l09)/i                      // Huawei
             ], [MODEL, [VENDOR, 'Huawei'], [TYPE, MOBILE]], [
 
             /android.+(bah2?-a?[lw]\d{2})/i                                     // Huawei MediaPad

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1132,5 +1132,14 @@
           "model": "EML-L29",
           "type": "mobile"
       }
+  },
+  {
+    "desc": "Huawei Mate 20 Pro",
+    "ua": "Mozilla/5.0 (Linux; Android 9; LYA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36",
+    "expect": {
+        "vendor": "Huawei",
+        "model": "LYA-L09",
+        "type": "mobile"
+    }
   }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1150,5 +1150,50 @@
         "model": "LYA-L09",
         "type": "mobile"
     }
+  },
+  {
+    "desc": "Huawei Mate 20 Pro",
+    "ua": "Mozilla/5.0 (Linux; Android 9; LYA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36",
+    "expect": {
+        "vendor": "Huawei",
+        "model": "LYA-AL00",
+        "type": "mobile"
+    }
+  },
+  {
+    "desc": "Huawei Mate 20 Pro",
+    "ua": "Mozilla/5.0 (Linux; Android 9; LYA-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36",
+    "expect": {
+        "vendor": "Huawei",
+        "model": "LYA-AL10",
+        "type": "mobile"
+    }
+  },
+  {
+    "desc": "Huawei Mate 20 Pro",
+    "ua": "Mozilla/5.0 (Linux; Android 9; LYA-L0C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36",
+    "expect": {
+        "vendor": "Huawei",
+        "model": "LYA-L0C",
+        "type": "mobile"
+    }
+  },
+  {
+    "desc": "Huawei Mate 20 Pro",
+    "ua": "Mozilla/5.0 (Linux; Android 9; LYA-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36",
+    "expect": {
+        "vendor": "Huawei",
+        "model": "LYA-L29",
+        "type": "mobile"
+    }
+  },
+  {
+    "desc": "Huawei Mate 20 Pro",
+    "ua": "Mozilla/5.0 (Linux; Android 9; LYA-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36",
+    "expect": {
+        "vendor": "Huawei",
+        "model": "LYA-TL00",
+        "type": "mobile"
+    }
   }
 ]

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1134,6 +1134,15 @@
       }
   },
   {
+    "desc": "Huawei P20 Pro",
+    "ua": "Mozilla/5.0 (Linux; Android 9; CLT-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36",
+    "expect": {
+        "vendor": "Huawei",
+        "model": "CLT-L29",
+        "type": "mobile"
+    }
+  },
+  {
     "desc": "Huawei Mate 20 Pro",
     "ua": "Mozilla/5.0 (Linux; Android 9; LYA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36",
     "expect": {


### PR DESCRIPTION
This PR adds additional detection for the Huawei P20 Pro and all of the different models of the Huawei Mate P20 Pro.