### PR TITLE
No need for type="text/javascript"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,8 +113,8 @@ WebOS, Windows [Phone/Mobile], Zenwalk, ...
 <!doctype html>
 <html>
 <head>
-<script type="text/javascript" src="ua-parser.min.js"></script>
-<script type="text/javascript">
+<script src="ua-parser.min.js"></script>
+<script>
 
     var parser = new UAParser();
 

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ WebOS, Windows [Phone/Mobile], Zenwalk, ...
 <script type="text/javascript" src="ua-parser.min.js"></script>
 <script type="text/javascript">
 
-	var parser = new UAParser();
+    var parser = new UAParser();
 
     // by default it takes ua string from current browser's window.navigator.userAgent
     console.log(parser.getResult());


### PR DESCRIPTION
No need to specify `type="text/javascript"` with `script` tag:

`<script type="text/javascript" src="ua-parser.min.js"></script>`
simply becomes
`<script src="ua-parser.min.js"></script>`

Supported by all browsers, the `type` attribute is optional and HTML5 defaults to "text/javascript"

Easier to read :-)