### PR TITLE
Fix "lang" selector in url 

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
 
       function trans(key) {
           var matchLang = location.search.match(/lang=([a-z]+)/);
-	  var queryLang = matchLang ? matchLang[1] : null;
+          var queryLang = matchLang ? matchLang[1] : null;
           var locale = queryLang || navigator.language || navigator.userLanguage; 
           var translations = getTranslations();
 

--- a/index.html
+++ b/index.html
@@ -286,7 +286,8 @@
       }
 
       function trans(key) {
-          const queryLang = location.search.match(/lang=([a-z]+)/);
+          var matchLang = location.search.match(/lang=([a-z]+)/);
+	  var queryLang = matchLang ? matchLang[1] : null;
           var locale = queryLang || navigator.language || navigator.userLanguage; 
           var translations = getTranslations();
 


### PR DESCRIPTION
`location.search.match(/lang=([a-z]+)/)` does return `['lang=fr', 'fr']` if it does match and thus does not found the language with the query parameter.

This commit fixes this comportment.