### PR TITLE
Detect SM-P610 / Samsung Galaxy Tab S6 Lite as tablet

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -525,7 +525,7 @@
             /\(dtv[\);].+(aquos)/i                                              // Sharp
             ], [MODEL, [VENDOR, 'Sharp'], [TYPE, SMARTTV]], [
 
-            /android.+((sch-i[89]0\d|shw-m380s|gt-p\d{4}|gt-n\d+|sgh-t8[56]9|nexus 10))/i,
+            /android.+((sch-i[89]0\d|shw-m380s|SM-P610|gt-p\d{4}|gt-n\d+|sgh-t8[56]9|nexus 10))/i,
             /((SM-T\w+))/i
             ], [[VENDOR, 'Samsung'], MODEL, [TYPE, TABLET]], [                  // Samsung
             /smart-tv.+(samsung)/i

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -352,6 +352,15 @@
         }
     },
     {
+        "desc": "Samsung Galaxy Tab 6 Lite",
+        "ua": "Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-P610) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Safari/537.36",
+        "expect": {
+            "vendor": "Samsung",
+            "model": "SM-P610",
+            "type": "tablet"
+        }
+    },
+    {
         "desc": "Samsung SM-T700",
         "ua": "Mozilla/5.0 (Linux; Android 4.4.2; SM-T700 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Safari/537.36",
         "expect": {


### PR DESCRIPTION
It is a tablet and not a phone.