### PR TITLE
Detect Samsung Note 10.1 as a tablet

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -525,7 +525,7 @@
             /\(dtv[\);].+(aquos)/i                                              // Sharp
             ], [MODEL, [VENDOR, 'Sharp'], [TYPE, SMARTTV]], [
 
-            /android.+((sch-i[89]0\d|shw-m380s|gt-p\d{4}|gt-n\d+|sgh-t8[56]9|nexus 10))/i,
+            /android.+((sch-i[89]0\d|shw-m380s|SM-P605|gt-p\d{4}|gt-n\d+|sgh-t8[56]9|nexus 10))/i,
             /((SM-T\w+))/i
             ], [[VENDOR, 'Samsung'], MODEL, [TYPE, TABLET]], [                  // Samsung
             /smart-tv.+(samsung)/i

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -379,6 +379,15 @@
         }
     },
     {
+        "desc": "Samsung Note 10.1",
+        "ua": "Mozilla/5.0 (Linux; Android 5.1.1; SM-P605) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36",
+        "expect": {
+          "vendor": "Samsung",
+          "model": "SM-P605",
+          "type": "tablet"
+        }
+    },
+    {
         "desc": "Samsung SmartTV2012",
         "ua": "HbbTV/1.1.1 (;Samsung;SmartTV2012;;;) WebKit",
         "expect": {


### PR DESCRIPTION
The Samsung Galaxy Note 10.1 (SM-P605) is detected as a phone. But it is a tablet.

Example UA String:
Mozilla/5.0 (Linux; Android 5.1.1; SM-P605) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36