### PR TITLE
Extract Chromecast firmware version

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -731,6 +731,10 @@
             /mozilla.+\(mobile;.+gecko.+firefox/i                               // Firefox OS
             ], [[NAME, 'Firefox OS'], VERSION], [
 
+            // Google Chromecast
+            /crkey\/([\d\.]+)/i                                                 // Google Chromecast
+            ], [VERSION, [NAME, 'Chromecast']], [
+
             // Console
             /(nintendo|playstation)\s([wids34portablevu]+)/i,                   // Nintendo/Playstation
 

--- a/test/os-test.json
+++ b/test/os-test.json
@@ -252,6 +252,15 @@
         }
     },
     {
+        "desc"    : "Google Chromecast",
+        "ua"      : "Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.81 Safari/537.36 CrKey/1.42.183786",
+        "expect"  :
+        {
+            "name"    : "Chromecast",
+            "version" : "1.42.183786"
+        }
+    },
+    {
         "desc"    : "Nintendo",
         "ua"      : "",
         "expect"  :


### PR DESCRIPTION
Rather than put the CPU type as the OS version, for Chromecast, the
firmware version would be much more useful.

For example:

  Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like
  Gecko) Chrome/76.0.3809.81 Safari/537.36 CrKey/1.42.183786

This should produce:

  os: { name: "Chromecast", version: "1.42.183786" }

Instead of:

  os: { name: "Linux", version: "aarch64" }