### PR TITLE
Fix ReDoS patch

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -585,9 +585,9 @@
             /android.+(hm[\s\-_]*note?[\s_]*(?:\d\w)?)\s+build/i,               // Xiaomi Hongmi
             /android.+(mi[\s\-_]*(?:a\d|one|one[\s_]plus|note lte)?[\s_]*(?:\d?\w?)[\s_]*(?:plus)?)\s+build/i,    
                                                                                 // Xiaomi Mi
-            /android.+(redmi[\s\-_]*(?:note)?(?:[\s_]?[\w\s]+))\s+build/i       // Redmi Phones
+            /android.+(redmi[\s\-_]*(?:note)?[\w\s]+)build/i       // Redmi Phones
             ], [[MODEL, /_/g, ' '], [VENDOR, 'Xiaomi'], [TYPE, MOBILE]], [
-            /android.+(mi[\s\-_]*(?:pad)(?:[\s_]?[\w\s]+))\s+build/i            // Mi Pad tablets
+            /android.+(mi[\s\-_]*(?:pad)[\w\s]+)build/i            // Mi Pad tablets
             ],[[MODEL, /_/g, ' '], [VENDOR, 'Xiaomi'], [TYPE, TABLET]], [
             /android.+;\s(m[1-5]\snote)\sbuild/i                                // Meizu
             ], [MODEL, [VENDOR, 'Meizu'], [TYPE, MOBILE]], [


### PR DESCRIPTION
Commit 233d3b fixed a ReDoS case caused by `A*A+`, where `A` is a
set of chars. However, said change is not equivalent nor optimal
which this fixes.