### PR TITLE
Bump version for all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,10 +115,10 @@
     ]
   },
   "devDependencies": {
-    "jshint": "~1.1.0",
-    "mocha": "~1.8.0",
+    "jshint": "~2.12.0",
+    "mocha": "~8.2.0",
     "requirejs": "^2.3.2",
-    "uglify-js": "~2.7.5",
+    "uglify-js": "~3.12.0",
     "verup": "^1.3.x"
   },
   "repository": {


### PR DESCRIPTION
This PR updates three of the development dependencies (jshint, mocha, and uglify-js) to require their latest versions.  Not only would they not display any results when running the tests, but this fixes FOUR security vulnerabilities (two medium, one high, and one critical).
