### PR TITLE
Improve detection for Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "Sylvain Gizard <sylvain.gizard@gmail.com>",
     "szchenghuang <szchenghuang@gmail.com>",
     "Vadim Kurachevsky <vadim@hmvs.org>",
+    "Vinyl Darkscratch <vinyldarkscratch@gooborg.com",
     "Yun Young-jin <yupmin@yupmin-office-macmini.local>"
   ],
   "main": "src/ua-parser.js",

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -377,7 +377,7 @@
             /(swiftfox)/i,                                                      // Swiftfox
             /(icedragon|iceweasel|camino|chimera|fennec|maemo\sbrowser|minimo|conkeror)[\/\s]?([\w\.\+]+)/i,
                                                                                 // IceDragon/Iceweasel/Camino/Chimera/Fennec/Maemo/Minimo/Conkeror
-            /(firefox|seamonkey|k-meleon|icecat|iceape|firebird|phoenix|palemoon|basilisk|waterfox)\/([\w\.-]+)$/i,
+            /(firefox|seamonkey|k-meleon|icecat|iceape|firebird|phoenix|palemoon|basilisk|waterfox)\/([\w\.-]+)(\s\(.*\))?$/i,
 
                                                                                 // Firefox/SeaMonkey/K-Meleon/IceCat/IceApe/Firebird/Phoenix
             /(mozilla)\/([\w\.]+).+rv\:.+gecko\/\d+/i,                          // Mozilla

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -351,6 +351,16 @@
     },
     {
         "desc"    : "Firefox",
+        "ua"      : "Mozilla/5.0 (Windows; U; Windows NT 5.2; en-US; rv:1.9.2.17) Gecko/20110420 Firefox/3.6.17 (.NET CLR 3.5.21022)",
+        "expect"  :
+        {
+            "name"    : "Firefox",
+            "version" : "3.6.17",
+            "major"   : "3"
+        }
+    },
+    {
+        "desc"    : "Firefox",
         "ua"      : "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
         "expect"  :
         {


### PR DESCRIPTION
This PR fixes #461 by improving Firefox detection.  In Firefox 3.6 on BrowserStack, some data for the .NET version is included at the end, which messes up detection.  This PR resolves it by adding a capture for such strings.﻿
