### PR TITLE
Update readme playstation typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ AIX, Amiga OS, Android, Arch, Bada, BeOS, BlackBerry, CentOS, Chromium OS,
 Contiki, Fedora, Firefox OS, FreeBSD, Debian, DragonFly, Fuchsia, Gentoo, GNU,
 Haiku, Hurd, iOS, Joli, KaiOS, Linpus, Linux, Mac OS, Mageia, Mandriva, MeeGo,
 Minix, Mint, Morph OS, NetBSD, Nintendo, OpenBSD, OpenVMS, OS/2, Palm, PC-BSD,
-PCLinuxOS, Plan9, Playstation, QNX, RedHat, RIM Tablet OS, RISC OS, Sailfish,
+PCLinuxOS, Plan9, PlayStation, QNX, RedHat, RIM Tablet OS, RISC OS, Sailfish,
 Series40, Slackware, Solaris, SUSE, Symbian, Tizen, Ubuntu, Unix, VectorLinux,
 WebOS, Windows [Phone/Mobile], Zenwalk, ...
 


### PR DESCRIPTION
Update Playstation to PlayStation as "Playstation" is not a known user agent. 

This is a really picky but this tripped us up at work as based on the Readme it sounds like "Playstation" would be the return from `getOS` when in fact it is not a known user agent. 

User agents referenced from: https://developers.whatismybrowser.com/useragents/explore/hardware_type_specific/game-console/