### PR TITLE
Fallback for Mobile

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -689,7 +689,10 @@
             ], [[TYPE, SMARTTV]], [
 
             /(android[\w\.\s\-]{0,9});.+build/i                                 // Generic Android Device
-            ], [MODEL, [VENDOR, 'Generic']]
+            ], [MODEL, [VENDOR, 'Generic']], [
+
+            /(phone)/i,
+            ], [[TYPE, MOBILE]]
         ],
 
         engine : [[

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1326,5 +1326,12 @@
         "model": "LYA-TL00",
         "type": "mobile"
     }
+  },
+  {
+    "desc": "FaceBook Mobile App",
+    "ua": "[FBAN/FBIOS;FBAV/283.0.0.44.117;FBBV/238386386;FBDV/iPhone12,1;FBMD/iPhone;FBSN/iOS;FBSV/13.6.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBRV/240127608]",
+    "expect": {
+        "type": "mobile"
+    }
   }
 ]


### PR DESCRIPTION
I'm not 100% sure what combination of device and app causes the Facebook User Agent to not include any browser info but this problem could be solved by having a generic callback for `phone` to be classified as mobile.