### PR TITLE
FIX: Wechat Desktop for Windows compatible with new version

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -282,7 +282,7 @@
             /(comodo_dragon)\/([\w\.]+)/i                                       // Comodo Dragon
             ], [[NAME, /_/g, ' '], VERSION], [
 
-            /((?:windowswechat)? qbcore)\/([\w\.]+)(?:.+windowswechat)?/i,      // WeChat Desktop for Windows Built-in Browser
+            /((?:windowswechat)? qbcore)\/([\w\.]+).*(?:windowswechat)?/i,      // WeChat Desktop for Windows Built-in Browser
             ], [[NAME, 'WeChat(Win) Desktop'], VERSION], [
 
             /(micromessenger)\/([\w\.]+)/i                                      // WeChat

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -282,7 +282,7 @@
             /(comodo_dragon)\/([\w\.]+)/i                                       // Comodo Dragon
             ], [[NAME, /_/g, ' '], VERSION], [
 
-            /(windowswechat qbcore)\/([\w\.]+)/i                                // WeChat Desktop for Windows Built-in Browser
+            /((?:windowswechat)? qbcore)\/([\w\.]+)(?:.+windowswechat)?/i,      // WeChat Desktop for Windows Built-in Browser
             ], [[NAME, 'WeChat(Win) Desktop'], VERSION], [
 
             /(micromessenger)\/([\w\.]+)/i                                      // WeChat

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -1189,6 +1189,16 @@
         }
     },
     {
+        "desc"    : "WeChat Desktop for Windows Built-in Browser major version in 4",
+        "ua"      : "mozilla/5.0 (windows nt 10.0; wow64) applewebkit/537.36 (khtml, like gecko) chrome/53.0.2785.116 safari/537.36 qbcore/4.0.1301.400 qqbrowser/9.0.2524.400 mozilla/5.0 (windows nt 6.1; wow64) applewebkit/537.36 (khtml, like gecko) chrome/81.0.4044.138 safari/537.36 nettype/wifi micromessenger/7.0.20.1781(0x6700143b) windowswechat",
+        "expect"  :
+        {
+            "name"    : "WeChat(Win) Desktop",
+            "version" : "4.0.1301.400",
+            "major"   : "4"
+        }
+    },
+    {
         "desc"    : "GSA on iOS",
         "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) GSA/30.1.161623614 Mobile/14F89 Safari/602.1",
         "expect"  :


### PR DESCRIPTION
With the update of wechat desktop software, it is judged that the browser version information in Windows wechat desktop software has been invalid, and it needs to be compatible.