### PR TITLE
Move to check typeof for window for different envs

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -811,7 +811,7 @@
             return new UAParser(uastring, extensions).getResult();
         }
 
-        var ua = uastring || ((window && window.navigator && window.navigator.userAgent) ? window.navigator.userAgent : EMPTY);
+        var ua = uastring || ((typeof window !== 'undefined' && window.navigator && window.navigator.userAgent) ? window.navigator.userAgent : EMPTY);
         var rgxmap = extensions ? util.extend(regexes, extensions) : regexes;
 
         this.getBrowser = function () {
@@ -907,7 +907,7 @@
             define(function () {
                 return UAParser;
             });
-        } else if (window) {
+        } else if (typeof window !== 'undefined') {
             // browser env
             window.UAParser = UAParser;
         }
@@ -918,7 +918,7 @@
     //   In AMD env the global scope should be kept clean, but jQuery is an exception.
     //   jQuery always exports to global scope, unless jQuery.noConflict(true) is used,
     //   and we should catch that.
-    var $ = window && (window.jQuery || window.Zepto);
+    var $ = typeof window !== 'undefined' && (window.jQuery || window.Zepto);
     if ($ && !$.ua) {
         var parser = new UAParser();
         $.ua = parser.getResult();


### PR DESCRIPTION
This is an awesome package, and because its so small and useful you can use it in many different places, including situations where `window` will be undefined entirely. 

We use this function in [Bigquery Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions) and in [Rudderstack transformations](https://rudderstack.com/blog/introducing-rudderstack-transformations). In both of these scenarios `window` isn't even defined so we've changed the package slightly. 

This PR addresses this issue and checks `typeof` instead of `window` variable to allow for use in different environments.