### PR TITLE
Add string check to setUA method

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -804,7 +804,7 @@
             return _ua;
         };
         this.setUA = function (ua) {
-            _ua = ua.length > UA_MAX_LENGTH ? util.trim(ua, UA_MAX_LENGTH) : ua;
+            _ua = (typeof ua === STR_TYPE && ua.length > UA_MAX_LENGTH) ? util.trim(ua, UA_MAX_LENGTH) : ua;
             return this;
         };
         this.setUA(_ua);

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,14 @@ describe('UAParser()', function () {
     assert.deepStrictEqual(UAParser(ua), new UAParser().setUA(ua).getResult());
 });
 
+describe('UAParser() constructor does not throw with undefined ua argument', function () {
+    assert.doesNotThrow(() => new UAParser(undefined).getResult());
+});
+
+describe('UAParser.setUA method does not throw with undefined ua argument', function () {
+    assert.doesNotThrow(() => new UAParser().setUA(undefined).getResult());
+});
+
 for (var i in methods) {
     describe(methods[i]['title'], function () {
         for (var j in methods[i]['list']) {


### PR DESCRIPTION
Fix [limit to maximum ua string length](https://github.com/faisalman/ua-parser-js/commit/8c2b84fc31f62a4de9f8b1a6742097af4b73cf08#diff-50cb887678582ceb3092db7aaaaca9c59b3b94f547119c83302fa8f73d19e371R780) - this change emit error, when passed ua argument is `undefined`.