### PR TITLE
Detect running inside Microsoft Teams desktop application

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -268,6 +268,8 @@
             ], [[NAME, /(.+)/, '$1 '+BROWSER], VERSION], [                      // Oculus/Samsung/Sailfish Browser
             /(comodo_dragon)\/([\w\.]+)/i                                       // Comodo Dragon
             ], [[NAME, /_/g, ' '], VERSION], [
+            /teams\/([\w\.]+)/i                                                 // Microsoft Teams
+            ], [VERSION, [NAME, 'Microsoft Teams']], [
             /(electron)\/([\w\.]+) safari/i,                                    // Electron-based App
             /(tesla)(?: qtcarbrowser|\/(20\d\d\.[-\w\.]+))/i,                   // Tesla
             /m?(qqbrowser|baiduboxapp|2345Explorer)[\/ ]?([\w\.]+)/i            // QQBrowser/Baidu App/2345 Browser

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -1279,6 +1279,16 @@
         }
     },
     {
+        "desc"    : "Microsoft Teams",
+        "ua"      : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_16_0) AppleWebKit/537.36 (KHTML, like Gecko) Teams/1.4.00.7175 Chrome/80.0.3987.163 Electron/8.5.5 Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "Microsoft Teams",
+            "version" : "1.4.00.7175",
+            "major"   : "1"
+        }
+    },
+    {
         "desc"    : "Iridium",
         "ua"      : "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Iridium/43.8 Safari/537.36 Chrome/43.0.2357.132",
         "expect"  :


### PR DESCRIPTION
Running inside Microsoft Teams as an add-on results in UAParser reporting Electron as the browser. Knowing that it's running inside Microsoft Teams would be more useful.