### PR TITLE
Change Chromium OS to Chrome OS for accuracy

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -715,8 +715,8 @@
             // Google Chromecast
             /crkey\/([\d\.]+)/i                                                 // Google Chromecast
             ], [VERSION, [NAME, CHROME+'cast']], [
-            /(cros) [\w]+ ([\w\.]+\w)/i                                         // Chromium OS
-            ], [[NAME, 'Chromium OS'], VERSION],[
+            /(cros) [\w]+ ([\w\.]+\w)/i                                         // Chrome OS
+            ], [[NAME, 'Chrome OS'], VERSION],[
 
             // Console
             /(nintendo|playstation) ([wids345portablevuch]+)/i,                 // Nintendo/Playstation


### PR DESCRIPTION
The "cros" identifier is accurate for both Chromium OS and Chrome OS. However, the relative popularity of Chrome OS means that the vast majority of the time, the user agent will be misidentified as Chromium OS when it is actually Chrome OS.

I've switched Chromium OS for Chrome OS in order to make the regex more accurate.