### PR TITLE
Add Oculus Quest and Oculus Quest 2, as well as another test for Oculus Browser

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -632,10 +632,8 @@
             ], [MODEL, [VENDOR, GOOGLE], [TYPE, WEARABLE]], [
             /droid.+; (wt63?0{2,3})\)/i
             ], [MODEL, [VENDOR, ZEBRA], [TYPE, WEARABLE]], [
-            /quest 2/i
-            ], [[MODEL, 'Quest 2'], [VENDOR, FACEBOOK], [TYPE, WEARABLE]], [
-            /quest/i
-            ], [[MODEL, 'Quest'], [VENDOR, FACEBOOK], [TYPE, WEARABLE]], [
+            /(quest( 2)?)/i                                                     // Oculus Quest
+            ], [MODEL, [VENDOR, FACEBOOK], [TYPE, WEARABLE]], [
 
             ///////////////////
             // EMBEDDED

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -56,7 +56,8 @@
         SAMSUNG = 'Samsung',
         SONY    = 'Sony',
         XIAOMI  = 'Xiaomi',
-        ZEBRA   = 'Zebra';
+        ZEBRA   = 'Zebra',
+        FACEBOOK   = 'Facebook';
 
     ///////////
     // Helper
@@ -278,7 +279,7 @@
 
             // WebView
             /((?:fban\/fbios|fb_iab\/fb4a)(?!.+fbav)|;fbav\/([\w\.]+);)/i       // Facebook App for iOS & Android
-            ], [[NAME, 'Facebook'], VERSION], [
+            ], [[NAME, FACEBOOK], VERSION], [
             /safari (line)\/([\w\.]+)/i,                                        // Line App for iOS
             /\b(line)\/([\w\.]+)\/iab/i,                                        // Line App for Android
             /(chromium|instagram)[\/ ]([-\w\.]+)/i                              // Chromium/Instagram
@@ -631,6 +632,10 @@
             ], [MODEL, [VENDOR, GOOGLE], [TYPE, WEARABLE]], [
             /droid.+; (wt63?0{2,3})\)/i
             ], [MODEL, [VENDOR, ZEBRA], [TYPE, WEARABLE]], [
+            /quest 2/i
+            ], [[MODEL, 'Quest 2'], [VENDOR, FACEBOOK], [TYPE, WEARABLE]], [
+            /quest/i
+            ], [[MODEL, 'Quest'], [VENDOR, FACEBOOK], [TYPE, WEARABLE]], [
 
             ///////////////////
             // EMBEDDED

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -804,8 +804,28 @@
         "expect"  :
         {
             "name"    : "Oculus Browser",
-            "version" : "3.4.9",
-            "major"   : "3"
+            "version" : "4.0.0.17",
+            "major"   : "4"
+        }
+    },
+    {
+        "desc"    : "Oculus Browser",
+        "ua"      : "Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/6.2.11.181027543 SamsungBrowser/4.0 Chrome/74.0.3729.182 Mobile VR Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "Oculus Browser",
+            "version" : "6.2.11.181027543",
+            "major"   : "6"
+        }
+    },
+    {
+        "desc"    : "Oculus Browser (NOTE PARIS FROM https://developer.oculus.com/documentation/web/browser-specs/)",
+        "ua"      : "Mozilla/5.0 (Linux; Android 10; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/15.0.0.0.22.280317669 SamsungBrowser/4.0 Chrome/89.0.4389.90 VR Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "Oculus Browser",
+            "version" : "15.0.0.0.22.280317669",
+            "major"   : "15"
         }
     },
     {

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -789,7 +789,7 @@
         }
     },
     {
-        "desc"    : "Oculus Browser",  
+        "desc"    : "Oculus Browser",
         "ua"      : "Mozilla/5.0 (Linux; Android 7.0; SM-G920I Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/3.4.9 SamsungBrowser/4.0 Chrome/57.0.2987.146 Mobile VR Safari/537.36",
         "expect"  :
         {
@@ -800,26 +800,6 @@
     },
     {
         "desc"    : "Oculus Browser",
-        "ua"      : "Mozilla/5.0 (Linux; Android 7.1.1; Pacific Build/N9F27L) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/4.0.0.17 SamsungBrowser/4.0 Chrome/61.0.3163.109 Mobile VR Safari/537.36",
-        "expect"  :
-        {
-            "name"    : "Oculus Browser",
-            "version" : "4.0.0.17",
-            "major"   : "4"
-        }
-    },
-    {
-        "desc"    : "Oculus Browser",
-        "ua"      : "Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/6.2.11.181027543 SamsungBrowser/4.0 Chrome/74.0.3729.182 Mobile VR Safari/537.36",
-        "expect"  :
-        {
-            "name"    : "Oculus Browser",
-            "version" : "6.2.11.181027543",
-            "major"   : "6"
-        }
-    },
-    {
-        "desc"    : "Oculus Browser (NOTE PARIS FROM https://developer.oculus.com/documentation/web/browser-specs/)",
         "ua"      : "Mozilla/5.0 (Linux; Android 10; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/15.0.0.0.22.280317669 SamsungBrowser/4.0 Chrome/89.0.4389.90 VR Safari/537.36",
         "expect"  :
         {

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -789,8 +789,18 @@
         }
     },
     {
-        "desc"    : "Oculus Browser",
+        "desc"    : "Oculus Browser",  
         "ua"      : "Mozilla/5.0 (Linux; Android 7.0; SM-G920I Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/3.4.9 SamsungBrowser/4.0 Chrome/57.0.2987.146 Mobile VR Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "Oculus Browser",
+            "version" : "3.4.9",
+            "major"   : "3"
+        }
+    },
+    {
+        "desc"    : "Oculus Browser",
+        "ua"      : "Mozilla/5.0 (Linux; Android 7.1.1; Pacific Build/N9F27L) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/4.0.0.17 SamsungBrowser/4.0 Chrome/61.0.3163.109 Mobile VR Safari/537.36",
         "expect"  :
         {
             "name"    : "Oculus Browser",

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1054,6 +1054,24 @@
         }
     },
     {
+        "desc": "Oculus Quest",
+        "ua": "Mozilla/5.0 (Linux; Android 10; Quest) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/15.0.0.0.22.280317669 SamsungBrowser/4.0 Chrome/89.0.4389.90 VR Safari/537.36",
+        "expect": {
+            "vendor": "Facebook",
+            "model": "Quest",
+            "type": "wearable"
+        }
+    },
+    {
+        "desc": "Oculus Quest 2",
+        "ua": "Mozilla/5.0 (Linux; Android 10; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/15.0.0.0.22.280317669 SamsungBrowser/4.0 Chrome/89.0.4389.90 VR Safari/537.36",
+        "expect": {
+            "vendor": "Facebook",
+            "model": "Quest 2",
+            "type": "wearable"
+        }
+    },
+    {
         "desc": "OnePlus One",
         "ua": "Mozilla/5.0 (Linux; Android 4.4.4; A0001 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Mobile Safari/537.36",
         "expect": {

--- a/test/test.js
+++ b/test/test.js
@@ -39,8 +39,7 @@ var methods     = [
         label       : 'os',
         list        : os,
         properties  : ['name', 'version']
-    }
-];
+}];
 
 describe('UAParser()', function () {
     var ua = 'Mozilla/5.0 (Windows NT 6.2) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1090.0 Safari/536.6';
@@ -63,6 +62,7 @@ for (var i in methods) {
                     describe('"' + methods[i]['list'][j].ua + '"', function () {
                         var expect = methods[i]['list'][j].expect;
                         var result = parser.setUA(methods[i]['list'][j].ua).getResult()[methods[i]['label']];
+
                         methods[i]['properties'].forEach(function(m) {
                             it('should return ' + methods[i]['label'] + ' ' + m + ': ' + expect[m], function () {
                                 assert.strictEqual(result[m], expect[m] != 'undefined' ? expect[m] : undefined);

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,8 @@ var methods     = [
         label       : 'os',
         list        : os,
         properties  : ['name', 'version']
-}];
+    }
+];
 
 describe('UAParser()', function () {
     var ua = 'Mozilla/5.0 (Windows NT 6.2) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1090.0 Safari/536.6';
@@ -62,7 +63,6 @@ for (var i in methods) {
                     describe('"' + methods[i]['list'][j].ua + '"', function () {
                         var expect = methods[i]['list'][j].expect;
                         var result = parser.setUA(methods[i]['list'][j].ua).getResult()[methods[i]['label']];
-
                         methods[i]['properties'].forEach(function(m) {
                             it('should return ' + methods[i]['label'] + ' ' + m + ': ' + expect[m], function () {
                                 assert.strictEqual(result[m], expect[m] != 'undefined' ? expect[m] : undefined);


### PR DESCRIPTION
### What
Based on https://developer.oculus.com/documentation/web/browser-specs/, which says:
> The user-agent (UA) string for Oculus Browser is:
>
>Mozilla/5.0 (Linux; Android 10; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/15.0.0.0.22.280317669 SamsungBrowser/4.0 Chrome/89.0.4389.90 VR Safari/537.36
>
>The UA string should not be used for feature detection. The UA string token for Oculus Quest devices is “Quest” and Oculus Quest 2 is “Quest 2”. Oculus Browser allows users to switch into mobile mode, in which case the “VR” token above becomes “Mobile VR”. Note the Browser and Chromium version numbers may be newer than stated above.

we:
* Add device model detection of Oculus Quest and Oculus Quest 2.
* Add their provided user agent as a unit test in the Oculus Browser detection page. This doesn't require any changes to the detection, but thought it was useful to still add as a regression test. But happy to remove if you'd like.

### Open questions
* I used `"model": "Quest"` and  `"model": "Quest 2",` - is that what we want? Couldn't find much online about it.
* Is there a better regex we would prefer for Oculus Quest and Oculus Quest 2? I just did very basic string matching..

### Testing
Tests pass:
```
~/repo/ua-parser-jparismorgan$ npm run test                                                                                                                                                                                                                                                                                                                                                                                                                                      130 ↵  ✹oculus 

> ua-parser-js@0.7.28 test /Users/paris/repo/ua-parser-jparismorgan
> jshint src/ua-parser.js && mocha -R nyan test/test.js

 1979_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-__,------,
 0   _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-__|  /\_/\  
 0   _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_~|_( ^ .^)  
     _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_ ""  ""  

  1979 passing (8m)
```