### PR TITLE
Add support for HuaweiBrowser

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -211,6 +211,8 @@
             ], [VERSION, [NAME, 'Chrome']], [
             /edg(?:e|ios|a)?\/([\w\.]+)/i                                       // Microsoft Edge
             ], [VERSION, [NAME, 'Edge']], [
+            /HuaweiBrowser\/([\w\.]+)/i                                         // HuaweiBrowser
+            ], [VERSION, [NAME, 'HuaweiBrowser']], [
 
             // Presto based
             /(opera mini)\/([-\w\.]+)/i,                                        // Opera Mini

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -499,6 +499,46 @@
         }
     },
     {
+        "desc"    : "HuaweiBrowser",
+        "ua"      : "Mozilla/5.0 (Linux; Android 6.0.1; LYA-AL00；HMSCore/4.0.0 GMS/10.4 ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 HuaweiBrowser/10.0.3.102 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "HuaweiBrowser",
+            "version" : "10.0.3.102",
+            "major"   : "10"
+        }
+    },
+    {
+        "desc"    : "HuaweiBrowser",
+        "ua"      : "Mozilla/5.0 (Linux; Android 6.0.1; LYA-AL00；HMSCore/4.0.0 ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 HuaweiBrowser/10.0.3.102 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "HuaweiBrowser",
+            "version" : "10.0.3.102",
+            "major"   : "10"
+        }
+    },
+    {
+        "desc"    : "HuaweiBrowser",
+        "ua"      : "Mozilla/5.0 (Linux; Android 6.0.1; LYA-AL00；GMS/10.4 ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 HuaweiBrowser/10.0.3.102 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "HuaweiBrowser",
+            "version" : "10.0.3.102",
+            "major"   : "10"
+        }
+    },
+    {
+        "desc"    : "HuaweiBrowser",
+        "ua"      : "Mozilla/5.0 (Linux; Android 6.0.1; LYA-AL00 ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 HuaweiBrowser/10.0.3.102 Mobile Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "HuaweiBrowser",
+            "version" : "10.0.3.102",
+            "major"   : "10"
+        }
+    },
+    {
         "desc"    : "IceApe",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.19) Gecko/20110817 Iceape/2.0.14",
         "expect"  :


### PR DESCRIPTION
### What
We add support for HuaweiBrowser, which currently is being picked up as "Chrome" because our user agent has "Chrome" in it: `Mozilla/5.0 (Linux; Android 6.0.1; LYA-AL00 ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 HuaweiBrowser/10.0.3.102 Mobile Safari/537.36`.

### Tests
Adds user agents from this post: https://stackoverflow.com/a/66056392/4979029.

Tests pass:
```
~/repo/ua-parser-jparismorgan$ npm run test                                                                                                                                                                                                                                                       ✹HuaweiBrowser 

> ua-parser-js@0.7.31 test /Users/paris/repo/ua-parser-jparismorgan
> jshint src/ua-parser.js && mocha -R nyan test/test.js

 2058_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_,------,
 0   _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_|   /\_/\ 
 0   _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-^|__( ^ .^) 
     _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-  ""  "" 

  2058 passing (8s)
```