### PR TITLE
Add Yeti browser

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Linpus, Linspire,Linux, Mac OS, Maemo, Mageia, Mandriva, Manjaro, MeeGo, Minix,
 Mint, Morph OS, NetBSD, Nintendo, OpenBSD, OpenVMS, OS/2, Palm, PC-BSD, PCLinuxOS, 
 Plan9, PlayStation, QNX, Raspbian, RedHat, RIM Tablet OS, RISC OS, Sabayon, 
 Sailfish, Series40, Slackware, Solaris, SUSE, Symbian, Tizen, Ubuntu, Unix, 
-VectorLinux, WebOS, Windows [Phone/Mobile], Zenwalk, ...
+VectorLinux, WebOS, Windows [Phone/Mobile], Yeti, Zenwalk, ...
 
 # 'os.version' determined dynamically
 ```

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -231,7 +231,7 @@
             /(?:ms|\()(ie) ([\w\.]+)/i,                                         // Internet Explorer
 
             // Webkit/KHTML based                                               // Flock/RockMelt/Midori/Epiphany/Silk/Skyfire/Bolt/Iron/Iridium/PhantomJS/Bowser/QupZilla/Falkon
-            /(flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt|iron|vivaldi|iridium|phantomjs|bowser|quark|qupzilla|falkon|rekonq|puffin|brave|whale|qqbrowserlite|qq|duckduckgo)\/([-\w\.]+)/i,
+            /(flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt|iron|vivaldi|iridium|phantomjs|bowser|quark|qupzilla|falkon|rekonq|puffin|brave|whale|qqbrowserlite|qq|duckduckgo|yeti)\/([-\w\.]+)/i,
                                                                                 // Rekonq/Puffin/Brave/Whale/QQBrowserLite/QQ, aka ShouQ
             /(weibo)__([\d\.]+)/i                                               // Weibo
             ], [NAME, VERSION], [

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -1545,6 +1545,16 @@
         }
     },
     {
+        "desc"    : "Yeti",
+        "ua"      : "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.0 Safari/537.36 (compatible; Yeti/1.1; +http://naver.me/spd)",
+        "expect"  : 
+        {
+            "name"    : "Yeti",
+            "version" : "1.1",
+            "major"   : "1"
+        }
+    },
+    {
         "desc"    : "Electron",
         "ua"      : "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Atom/1.41.0 Chrome/69.0.3497.128 Electron/4.2.7 Safari/537.36",
         "expect"  :


### PR DESCRIPTION
### Overview
Adding Yeti browser to the list of possible Webkit/KHTML based browsers

### How to test
- [ ] `npm run test`