### PR TITLE
Export javascript module

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
     "Zach Bjornson <zbbjornson@gmail.com>"
   ],
   "main": "src/ua-parser.js",
+  "exports": {
+    ".": "./src/index.mjs"
+  },
   "scripts": {
     "build": "uglifyjs src/ua-parser.js -o dist/ua-parser.min.js --comments '/^ UA/' && uglifyjs src/ua-parser.js -o dist/ua-parser.pack.js --comments '/^ UA/' --compress --mangle",
     "test": "jshint src/ua-parser.js && mocha -R nyan test/test.js",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,3 @@
+import UAParser from "./ua-parser.js";
+
+export default UAParser;


### PR DESCRIPTION
Exporting as JavaScript module helps some bundlers like Rollup to skip processing the package with commonjs runtime. 

Details:
Rollup when loading a commonjs package with `preserveModules` options, has to wrapped them with a commonjs interop library. Normally this is not an issue, but in our use case, the `_virtual` folder created by Rollup was a problem. The simple workaround the problem was to monkey patch `ua-parser-js` to act like native JavaScript module.