### PR TITLE
Support Hbbtv devices

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ The methods are self explanatory, here's a small overview on all the available m
  *  `getBrowser()`      - returns the browser name and version.
  *  `getDevice()`       - returns the device model, type, vendor.
  *  `getEngine()`       - returns the current browser engine name and version.
+ *  `getHbbTv()`        - returns HbbTv information, if present.
  *  `getOS()`           - returns the running operating system name and version.
  *  `getCPU()`          - returns CPU architectural design name.
  *  `getUA()`           - returns the user-agent string.
@@ -189,6 +190,14 @@ VectorLinux, WebOS, Windows [Phone/Mobile], Zenwalk, ...
             engine: {
                 name: "",
                 version: ""
+            },
+            hbbtv: {
+                version: "",
+                capabilities: "",
+                "vendor": "",
+                "model": "",
+                "software": "",
+                "hardware": ""
             },
             os: {
                 name: "",

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -52,6 +52,7 @@
         LG      = 'LG',
         MICROSOFT = 'Microsoft',
         MOTOROLA  = 'Motorola',
+        NETRANGE= 'Netrange',
         OPERA   = 'Opera',
         PANASONIC = 'Panasonic',
         SAMSUNG = 'Samsung',
@@ -734,8 +735,10 @@
             ], [[NAME, 'Chromium OS'], VERSION],[
 
             // Smart TVs
-            /Panasonic;VIERA/i                                                // Panasonic Viera
+            /Panasonic;VIERA/i                                                  // Panasonic Viera
             ], [[NAME, VIERA]], [
+            /NETRANGEMMH/i                                                      // Netrange
+            ], [[NAME, NETRANGE]], [
 
 
             // Console

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -53,9 +53,11 @@
         MICROSOFT = 'Microsoft',
         MOTOROLA  = 'Motorola',
         OPERA   = 'Opera',
+        PANASONIC = 'Panasonic',
         SAMSUNG = 'Samsung',
         SHARP   = 'Sharp',
         SONY    = 'Sony',
+        VIERA   = 'Viera',
         XIAOMI  = 'Xiaomi',
         ZEBRA   = 'Zebra',
         FACEBOOK   = 'Facebook';
@@ -295,6 +297,8 @@
 
             / wv\).+(chrome)\/([\w\.]+)/i                                       // Chrome WebView
             ], [[NAME, CHROME+' WebView'], VERSION], [
+            /Panasonic;(VIERA)/i                                                // Panasonic Viera
+            ], [[NAME, VIERA]], [
 
             /droid.+ version\/([\w\.]+)\b.+(?:mobile safari|safari)/i           // Android Browser
             ], [VERSION, [NAME, 'Android '+BROWSER]], [
@@ -366,6 +370,35 @@
         ],
 
         device : [[
+
+            ///////////////////
+            // SMARTTVS
+            ///////////////////
+
+            /smart-tv.+(samsung)/i                                              // Samsung
+            ], [VENDOR, [TYPE, SMARTTV]], [
+            /hbbtv.+maple;(\d+)/i
+            ], [[MODEL, /^/, 'SmartTV'], [VENDOR, SAMSUNG], [TYPE, SMARTTV]], [
+            /(nux; netcast.+smarttv|lg (netcast\.tv-201\d|android tv))/i        // LG SmartTV
+            ], [[VENDOR, LG], [TYPE, SMARTTV]], [
+            /(apple) ?tv/i                                                      // Apple TV
+            ], [VENDOR, [MODEL, APPLE+' TV'], [TYPE, SMARTTV]], [
+            /crkey/i                                                            // Google Chromecast
+            ], [[MODEL, CHROME+'cast'], [VENDOR, GOOGLE], [TYPE, SMARTTV]], [
+            /droid.+aft(\w)( bui|\))/i                                          // Fire TV
+            ], [MODEL, [VENDOR, AMAZON], [TYPE, SMARTTV]], [
+            /\(dtv[\);].+(aquos)/i,
+            /(aquos-tv[\w ]+)\)/i                                               // Sharp
+            ], [MODEL, [VENDOR, SHARP], [TYPE, SMARTTV]],[
+            /(bravia[\w ]+)( bui|\))/i                                              // Sony
+            ], [MODEL, [VENDOR, SONY], [TYPE, SMARTTV]], [
+            /(mitv-\w{5}) bui/i                                                 // Xiaomi
+            ], [MODEL, [VENDOR, XIAOMI], [TYPE, SMARTTV]], [
+            /\b(roku)[\dx]*[\)\/]((?:dvp-)?[\d\.]*)/i,                          // Roku
+            /hbbtv\/\d+\.\d+\.\d+ +\([\w\+ ]*; *([\w\d][^;]*);([^;]*)/i         // HbbTV devices
+            ], [[VENDOR, trim], [MODEL, trim], [TYPE, SMARTTV]], [
+            /\b(android tv|smart[- ]?tv|opera tv|tv; rv:)\b/i                   // SmartTV from Unidentified Vendors
+            ], [[TYPE, SMARTTV]], [
 
             //////////////////////////
             // MOBILES & TABLETS
@@ -602,35 +635,6 @@
             ], [MODEL, [VENDOR, MICROSOFT], [TYPE, CONSOLE]], [
 
             ///////////////////
-            // SMARTTVS
-            ///////////////////
-
-            /smart-tv.+(samsung)/i                                              // Samsung
-            ], [VENDOR, [TYPE, SMARTTV]], [
-            /hbbtv.+maple;(\d+)/i
-            ], [[MODEL, /^/, 'SmartTV'], [VENDOR, SAMSUNG], [TYPE, SMARTTV]], [
-            /(nux; netcast.+smarttv|lg (netcast\.tv-201\d|android tv))/i        // LG SmartTV
-            ], [[VENDOR, LG], [TYPE, SMARTTV]], [
-            /(apple) ?tv/i                                                      // Apple TV
-            ], [VENDOR, [MODEL, APPLE+' TV'], [TYPE, SMARTTV]], [
-            /crkey/i                                                            // Google Chromecast
-            ], [[MODEL, CHROME+'cast'], [VENDOR, GOOGLE], [TYPE, SMARTTV]], [
-            /droid.+aft(\w)( bui|\))/i                                          // Fire TV
-            ], [MODEL, [VENDOR, AMAZON], [TYPE, SMARTTV]], [
-            /\(dtv[\);].+(aquos)/i,
-            /(aquos-tv[\w ]+)\)/i                                               // Sharp
-            ], [MODEL, [VENDOR, SHARP], [TYPE, SMARTTV]],[
-            /(bravia[\w ]+)( bui|\))/i                                              // Sony
-            ], [MODEL, [VENDOR, SONY], [TYPE, SMARTTV]], [
-            /(mitv-\w{5}) bui/i                                                 // Xiaomi
-            ], [MODEL, [VENDOR, XIAOMI], [TYPE, SMARTTV]], [
-            /\b(roku)[\dx]*[\)\/]((?:dvp-)?[\d\.]*)/i,                          // Roku
-            /hbbtv\/\d+\.\d+\.\d+ +\([\w ]*; *(\w[^;]*);([^;]*)/i               // HbbTV devices
-            ], [[VENDOR, trim], [MODEL, trim], [TYPE, SMARTTV]], [
-            /\b(android tv|smart[- ]?tv|opera tv|tv; rv:)\b/i                   // SmartTV from Unidentified Vendors
-            ], [[TYPE, SMARTTV]], [
-
-            ///////////////////
             // WEARABLES
             ///////////////////
 
@@ -729,9 +733,15 @@
             /(cros) [\w]+ ([\w\.]+\w)/i                                         // Chromium OS
             ], [[NAME, 'Chromium OS'], VERSION],[
 
+            // Smart TVs
+            /Panasonic;VIERA/i                                                // Panasonic Viera
+            ], [[NAME, VIERA]], [
+
+
             // Console
             /(nintendo|playstation) ([wids345portablevuch]+)/i,                 // Nintendo/Playstation
             /(xbox); +xbox ([^\);]+)/i,                                         // Microsoft Xbox (360, One, X, S, Series X, Series S)
+
 
             // Other
             /\b(joli|palm)\b ?(?:os)?\/?([\w\.]*)/i,                            // Joli/Palm

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -30,6 +30,9 @@
         TYPE        = 'type',
         VENDOR      = 'vendor',
         VERSION     = 'version',
+        CAPABILITIES= 'capabilities',
+        SOFTWARE    = 'software',
+        HARDWARE    = 'hardware',
         ARCHITECTURE= 'architecture',
         CONSOLE     = 'console',
         MOBILE      = 'mobile',
@@ -769,6 +772,10 @@
             /\b(beos|os\/2|amigaos|morphos|openvms|fuchsia|hp-ux)/i,            // BeOS/OS2/AmigaOS/MorphOS/OpenVMS/Fuchsia/HP-UX
             /(unix) ?([\w\.]*)/i                                                // UNIX
             ], [NAME, VERSION]
+        ],
+        hbbtv : [[
+            /hbbtv\/(\d+\.\d+\.\d*) +\(([^;]*); *([^;]*); *([^;]*); *([^;]*); *([^;]*)/i      // HbbTV directive
+            ], [VERSION, CAPABILITIES, [VENDOR, trim], [MODEL, trim], [SOFTWARE, trim], [HARDWARE, trim], [TYPE, SMARTTV]]
         ]
     };
 
@@ -819,6 +826,16 @@
             rgxMapper.call(_engine, _ua, _rgxmap.engine);
             return _engine;
         };
+        this.getHbbtv = function () {
+            var _hbbtv = {};
+            _hbbtv[VERSION] = undefined;
+            _hbbtv[VENDOR] = undefined;
+            _hbbtv[MODEL] = undefined;
+            _hbbtv[SOFTWARE] = undefined;
+            _hbbtv[HARDWARE] = undefined;
+            rgxMapper.call(_hbbtv, _ua, _rgxmap.hbbtv);
+            return _hbbtv;
+        };
         this.getOS = function () {
             var _os = {};
             _os[NAME] = undefined;
@@ -831,6 +848,7 @@
                 ua      : this.getUA(),
                 browser : this.getBrowser(),
                 engine  : this.getEngine(),
+                hbbtv   : this.getHbbtv(),
                 os      : this.getOS(),
                 device  : this.getDevice(),
                 cpu     : this.getCPU()
@@ -852,6 +870,7 @@
     UAParser.CPU = enumerize([ARCHITECTURE]);
     UAParser.DEVICE = enumerize([MODEL, VENDOR, TYPE, CONSOLE, MOBILE, SMARTTV, TABLET, WEARABLE, EMBEDDED]);
     UAParser.ENGINE = UAParser.OS = enumerize([NAME, VERSION]);
+    UAParser.HBBTV = enumerize([VERSION, VENDOR, MODEL, SOFTWARE, HARDWARE]);
 
     ///////////
     // Export

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -396,6 +396,8 @@
             ], [MODEL, [VENDOR, SONY], [TYPE, SMARTTV]], [
             /(mitv-\w{5}) bui/i                                                 // Xiaomi
             ], [MODEL, [VENDOR, XIAOMI], [TYPE, SMARTTV]], [
+            /Hbbtv.*(technisat) (.*);/i                                         // TechniSAT
+            ], [VENDOR, MODEL, [TYPE, SMARTTV]], [
             /\b(roku)[\dx]*[\)\/]((?:dvp-)?[\d\.]*)/i,                          // Roku
             /hbbtv\/\d+\.\d+\.\d+ +\([\w\+ ]*; *([\w\d][^;]*);([^;]*)/i         // HbbTV devices
             ], [[VENDOR, trim], [MODEL, trim], [TYPE, SMARTTV]], [

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -53,6 +53,7 @@
         MICROSOFT = 'Microsoft',
         MOTOROLA  = 'Motorola',
         NETRANGE= 'Netrange',
+        NETTV   = 'NetTV',
         OPERA   = 'Opera',
         PANASONIC = 'Panasonic',
         SAMSUNG = 'Samsung',
@@ -739,6 +740,8 @@
             ], [[NAME, VIERA]], [
             /NETRANGEMMH/i                                                      // Netrange
             ], [[NAME, NETRANGE]], [
+            /nettv\/(\d\.\d.\d)/i                                               // NetTV
+            ], [VERSION, [NAME, NETTV]], [
 
 
             // Console

--- a/test/browser-test.json
+++ b/test/browser-test.json
@@ -1279,6 +1279,16 @@
         }
     },
     {
+        "desc"    : "Viera",
+        "ua"      : "HbbTV/1.2.1 (;Panasonic;VIERA 2015;3.014;a001-003 4000-0000;)",
+        "expect"  :
+        {
+            "name"    : "Viera",
+            "version" : "undefined",
+            "major"   : "undefined"
+        }
+    },
+    {
         "desc"    : "Yandex",
         "ua"      : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/536.5 (KHTML, like Gecko) YaBrowser/1.0.1084.5402 Chrome/19.0.1084.5402 Safari/536.5",
         "expect"  :

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -791,6 +791,24 @@
         }
     },
     {
+        "desc": "JVC LT-43V55LFA Smart TV",
+        "ua": "Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.237.DOM3-OPT.245 Model/Vestel-MB211 VSTVB MB200 HbbTV/1.2.1 (; JVC; MB211; 3.19.4.2; _TV_NT72563_2017 SmartTvA/3.0.0",
+        "expect": {
+            "vendor": "JVC",
+            "model": "MB211",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "JVC LT-43V65LUA Smart TV",
+        "ua": "Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.237.DOM3-OPT.245 Model/Vestel-MB130 VSTVB MB100 HbbTV/1.2.1 (; JVC; MB130; 5.7.20.0; _TV_G10_2017;) SmartTvA/3.0.0",
+        "expect": {
+            "vendor": "JVC",
+            "model": "MB130",
+            "type": "smarttv"
+        }
+    },
+    {
         "desc": "Lenovo Tab 2",
         "ua": "Mozilla/5.0 (Linux; Android 5.0.1; Lenovo TAB 2 A7-30HC Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Safari/537.36",
         "expect": {

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -971,6 +971,15 @@
         }
     },
     {
+        "desc": "Loewe Smart TV",
+        "ua": "Mozilla/5.0 (Linux; U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36 OPR/46.0.2207.0 LOEWE-SL410/5.2.0.0 HbbTV/1.4.1 (; LOEWE; SL410; LOH/5.2.0.0;;) FVC/3.0 (LOEWE; SL410;) CE-HTML/1.0 Config (L:deu,CC:DEU) NETRANGEMMH",
+        "expect": {
+            "vendor": "LOEWE",
+            "model": "SL410",
+            "type": "smarttv"
+        }
+    },
+    {
         "desc": "Meizu M5 Note",
         "ua": "Mozilla/5.0 (Linux; Android 6.0; M5 Note Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043024 Safari/537.36 MicroMessenger/6.5.7.1040 NetType/WIFI Language/zh_CN",
         "expect": {

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -2046,6 +2046,26 @@
         }
     },
     {
+        "desc"    : "TechniSAT Digit ISIO S SAT receiver",
+        "ua"      : "Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO S; de) Presto/2.9.167 Version/11.50",
+        "expect"  :
+        {
+            "vendor": "TechniSat",
+            "model": "Digit ISIO S",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc"    : "TechniSAT MultyVision SmartTV",
+        "ua"      : "Opera/9.80 (Linux i686; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat MultyVision ISIO; de) Presto/2.9.167 Version/11.50",
+        "expect"  :
+        {
+            "vendor": "TechniSat",
+            "model": "MultyVision ISIO",
+            "type": "smarttv"
+        }
+    },
+    {
         "desc": "Xiaomi 2013023",
         "ua": "Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; 2013023 Build/HM2013023) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.1.512 U3/0.8.0 Mobile Safari/533.1",
         "expect": {

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1432,6 +1432,42 @@
         }
     },
     {
+        "desc": "Panasonic TX-32CSW514 SmartTV",
+        "ua": "HbbTV/1.2.1 (;Panasonic;VIERA 2015;3.014;a001-003 4000-0000;)",
+        "expect": {
+            "vendor": "Panasonic",
+            "model": "VIERA 2015",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "Panasonic TX-40FXW724 SmartTV",
+        "ua": "HbbTV/1.4.1 (+DRM;Panasonic;SmartTV2018mid;3.024;4301-0003 0002-0000;SmartTV2018;)",
+        "expect": {
+            "vendor": "Panasonic",
+            "model": "SmartTV2018mid",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "Panasonic TX-43HXW904 SmartTV",
+        "ua": "HbbTV/1.5.1 (+DRM;Panasonic;SmartTV2020mid;3.326;4301-0003 0008-0000;com.panasonic.SmartTV2020mid;)",
+        "expect": {
+            "vendor": "Panasonic",
+            "model": "SmartTV2020mid",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "Panasonic DMR-HST130 SAT receiver",
+        "ua": "HbbTV/1.1.1 (+PVR;Panasonic;DIGA WebKit M8658;3.420;;)",
+        "expect": {
+            "vendor": "Panasonic",
+            "model": "DIGA WebKit M8658",
+            "type": "smarttv"
+        }
+    },
+    {
         "desc": "Philips SmartTV",
         "ua": "Opera/9.80 HbbTV/1.1.1 (; Philips; ; ; ; ) NETTV/4.0.2; en) Version/11.60",
         "expect": {

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1504,6 +1504,33 @@
         }
     },
     {
+        "desc": "Philips 32PFL6606K/02 SmartTV (2011)",
+        "ua": "Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.1.0; en) Presto/2.6.33 Version/10.70",
+        "expect": {
+            "vendor": "Philips",
+            "model": "",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "Philips 32PFL6606K/02 SmartTV (2013)",
+        "ua": "Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.1.0; en) Presto/2.6.33 Version/10.70",
+        "expect": {
+            "vendor": "Philips",
+            "model": "",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "Philips 32PHS5301/12 SmartTV (2016)",
+        "ua": "Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 Safari/537.36 OPR/29.0.1803.0 OMI/4.5.23.37.MOT2.13 HbbTV/1.2.1 (;Philips;32PHS5301/12;;_TV_MT5800;) Firmware/TPM161E_012.002.045.001 en",
+        "expect": {
+            "vendor": "Philips",
+            "model": "32PHS5301/12",
+            "type": "smarttv"
+        }
+    },
+    {
         "desc": "Roku",
         "ua": "Mozilla/5.0 (Roku) AppleWebKit/537.36 (KHTML, like Gecko) Web/1.1 Safari/537.36",
         "expect": {

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1810,6 +1810,15 @@
         }
     },
     {
+        "desc": "Samsung SmartTV HBBTV",
+        "ua": "HbbTV/1.5.1 (+DRM;Samsung;SmartTV2021:UAU7000;T-KSU2EDEUC-1506.0;KantSU2e;urn:samsungtv:familyname:21_KANTSU2E_UHD_BASIC:2021;) Tizen/6.0 (+TVPLUS+SmartHubLink) Chrome/76 LaTivu_1.0.1_2021 RVID/17",
+        "expect": {
+            "vendor": "Samsung",
+            "model": "SmartTV2021:UAU7000",
+            "type": "smarttv"
+        }
+    },
+    {
         "desc": "Sharp AQUOS-TVX19B",
         "ua": "Mozilla/5.0 (Linux; Android 9; AQUOS-TVX19B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Mobile Safari/537.36",
         "expect": {

--- a/test/hbbtv-test.json
+++ b/test/hbbtv-test.json
@@ -1,0 +1,106 @@
+[
+    {
+        "desc"    : "Samsung SmartTV 2019",
+        "ua"      : "HbbTV/1.4.1 (+DRM;Samsung;SmartTV2019;URU7400;T-MSLDEUC-1315.4;Musel;urn;samsungtv:familyname:19_MUSEL_UHD:2019;) Tizen/5.0 (+TVPLUS+SmartHubLink) Chrome/63 LaTivu_1.0._2019 VID/14",
+        "expect"  :
+        {
+            "version" : "1.4.1",
+            "capabilities": "+DRM",
+            "vendor": "Samsung",
+            "model": "SmartTV2019",
+            "software": "URU7400",
+            "hardware": "T-MSLDEUC-1315.4"
+        }
+    },
+    {
+        "desc"    : "Samsung SmartTV 2020",
+        "ua"      : "HbbTV/1.4.1 (+DRM;Samsung;SmartTV2020:UTU7000;T-KTSU2DEUC-1302.5;KantSU2;urn:samsungtv:familyname:20_KANTSU2_UHD_BASIC:2020;) Tizen/5.5 (+TVPLUS+SmartHubLink) Chrome/69 LaTivu_1.0.1_2020 VID/35",
+        "expect"  :
+        {
+            "version" : "1.4.1",
+            "capabilities": "+DRM",
+            "vendor": "Samsung",
+            "model": "SmartTV2020:UTU7000",
+            "software": "T-KTSU2DEUC-1302.5",
+            "hardware": "KantSU2"
+        }
+    },
+    {
+        "desc"    : "Panasonic Viera 2016",
+        "ua"      : "HbbTV/1.2.1 (;Panasonic;VIERA 2016;3.280;7901-0003 0000-0100;)",
+        "expect"  :
+        {
+            "version" : "1.2.1",
+            "capabilities": "undefined",
+            "vendor": "Panasonic",
+            "model": "VIERA 2016",
+            "software": "3.280",
+            "hardware": "7901-0003 0000-0100"
+        }
+    },
+    {
+        "desc"    : "Samsung Maple",
+        "ua"      : "HbbTV/1.1.1 (;;;;;) Maple;2011",
+        "expect"  :
+        {
+            "version" : "1.1.1",
+            "capabilities": "",
+            "vendor": "",
+            "model": "",
+            "software": "",
+            "hardware": ""
+        }
+    },
+    {
+        "desc"    : "FireTV Stick",
+        "ua"      : "Mozilla/5.0 (Linux; Andr0id 9; AFTEU014 Build/PS7269) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36 OPR/46.0.2207.0 OMI/4.13.6.501.Sophia.507 HbbTV/1.5.1 (;Vewd;HbbTV add-on;;;;) FVC/4.0 (Vewd;;) smarttv_AFTEU014_Build_0022650019460_Chromium_67.0.3396.99",
+        "expect"  :
+        {
+            "version" : "1.5.1",
+            "capabilities": "",
+            "vendor": "Vewd",
+            "model": "HbbTV add-on",
+            "software": "",
+            "hardware": ""
+        }
+    },
+    {
+        "desc"    : "LG 2022",
+        "ua"      : "Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 HbbTV/1.6.1 (+DRM; LGE; 43UQ75009LF; WEBOS22 03.10.36; W22_K8LP; DTV_W22P;)",
+        "expect"  :
+        {
+            "version" : "1.6.1",
+            "capabilities": "+DRM",
+            "vendor": "LGE",
+            "model": "43UQ75009LF",
+            "software": "WEBOS22 03.10.36",
+            "hardware": "W22_K8LP"
+        }
+    },
+    {
+        "desc"    : "Broken version (Sony KDL-40W605B)",
+        "ua"      : "Opera/9.80 (Linux armv7l; HbbTV/1.1. (;Sony; KDL40W605B; PKG2.134EUA; 2014;);) Presto/2 12.407 Version/12.50",
+        "expect"  :
+        {
+            "version" : "1.1.",
+            "capabilities": "",
+            "vendor": "Sony",
+            "model": "KDL40W605B",
+            "software": "PKG2.134EUA",
+            "hardware": "2014"
+        }
+    },
+    {
+        "desc"    : "Missing closing bracket (JVC MB211)",
+        "ua"      : "Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.237.DOM3-OPT.245 Model/Vestel-MB211 VSTVB MB200 HbbTV/1.2.1 (; JVC; MB211; 3.19.4.2; _TV_NT72563_2017 SmartTvA/3.0.0",
+        "expect"  :
+        {
+            "version" : "1.2.1",
+            "capabilities": "",
+            "vendor": "JVC",
+            "model": "MB211",
+            "software": "3.19.4.2",
+            "hardware": "_TV_NT72563_2017 SmartTvA/3.0.0"
+        }
+    }
+]

--- a/test/os-test.json
+++ b/test/os-test.json
@@ -1044,6 +1044,15 @@
         }
     },
     {
+        "desc"    : "Panasonic Viera",
+        "ua"      : "HbbTV/1.2.1 (;Panasonic;VIERA 2015;3.014;a001-003 4000-0000;)",
+        "expect"  :
+        {
+            "name"    : "Viera",
+            "version" : "undefined"
+        }
+    },
+    {
         "desc"    : "HP-UX",
         "ua"      : "Mozilla/5.0 (X11; U; HP-UX 9000/785; es-ES; rv:1.0.1) Gecko/20020827 Netscape/7.0",
         "expect"  :

--- a/test/os-test.json
+++ b/test/os-test.json
@@ -1062,6 +1062,15 @@
         }
     },
     {
+        "desc"    : "NetTV 3.2.1",
+        "ua"      : "Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.2.1; en) Presto/2.6.33 Version/10.70",
+        "expect"  :
+        {
+            "name"    : "NetTV",
+            "version" : "3.2.1"
+        }
+    },
+    {
         "desc"    : "HP-UX",
         "ua"      : "Mozilla/5.0 (X11; U; HP-UX 9000/785; es-ES; rv:1.0.1) Gecko/20020827 Netscape/7.0",
         "expect"  :

--- a/test/os-test.json
+++ b/test/os-test.json
@@ -198,6 +198,15 @@
         }
     },
     {
+        "desc"    : "Tizen 6.0",
+        "ua"      : "HbbTV/1.5.1 (+DRM;Samsung;SmartTV2021:UAU7000;T-KSU2EDEUC-1506.0;KantSU2e;urn:samsungtv:familyname:21_KANTSU2E_UHD_BASIC:2021;) Tizen/6.0 (+TVPLUS+SmartHubLink) Chrome/76 LaTivu_1.0.1_2021 RVID/17",
+        "expect"  :
+        {
+            "name"    : "Tizen",
+            "version" : "6.0"
+        }
+    },
+    {
         "desc"    : "Android",
         "ua"      : "Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; VM670 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko)",
         "expect"  :

--- a/test/os-test.json
+++ b/test/os-test.json
@@ -1053,6 +1053,15 @@
         }
     },
     {
+        "desc"    : "Netrange Smart TV",
+        "ua"      : "Mozilla/5.0 (Linux; U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36 OPR/46.0.2207.0 LOEWE-SL410/5.2.0.0 HbbTV/1.4.1 (; LOEWE; SL410; LOH/5.2.0.0;;) FVC/3.0 (LOEWE; SL410;) CE-HTML/1.0 Config (L:deu,CC:DEU) NETRANGEMMH",
+        "expect"  :
+        {
+            "name"    : "Netrange",
+            "version" : "undefined"
+        }
+    },
+    {
         "desc"    : "HP-UX",
         "ua"      : "Mozilla/5.0 (X11; U; HP-UX 9000/785; es-ES; rv:1.0.1) Gecko/20020827 Netscape/7.0",
         "expect"  :

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ var browsers    = require('./browser-test.json');
 var cpus        = require('./cpu-test.json');
 var devices     = require('./device-test.json');
 var engines     = require('./engine-test.json');
+var hbbtvs      = require('./hbbtv-test.json');
 var os          = require('./os-test.json');
 var parser      = new UAParser();
 var methods     = [
@@ -35,6 +36,12 @@ var methods     = [
         label       : 'engine',
         list        : engines,
         properties  : ['name', 'version']
+    },
+    {
+        title       : 'getHbbtv',
+        label       : 'hbbtv',
+        list        : hbbtvs,
+        properties  : ['version', 'vendor', 'model', 'software', 'hardware']
     },
     {
         title       : 'getOS',
@@ -86,6 +93,7 @@ describe('Returns', function () {
                 cpu: { architecture: undefined },
                 device: { vendor: undefined, model: undefined, type: undefined },
                 engine: { name: undefined, version: undefined},
+                hbbtv: { version: undefined, vendor: undefined, model: undefined, software: undefined, hardware: undefined },
                 os: { name: undefined, version: undefined }
         });
         done();


### PR DESCRIPTION
Fixes: #607 
Supersedes: #609
Relates to: https://github.com/garritfra/ua-parser-js/pull/8

Adds support for HbbTv information. Since I didn't receive any feedback on #607, I implemented the proposed solution. I'm happy to make adjustments if needed.

Here's a simple example:

```js
    var parser = new UAParser();
    console.log(parser.getResult());

    var uastring = "Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (;Sony; KDL32CX525; PKG4.027EUA; 2011;);; en) Presto/2.7.61 Version/11.00";
    parser.setUA(uastring);
    var result = parser.getResult();

    console.log(result.hbbtv);
    /*
            {
                version: "1.1.1",
                capabilities: "",
                "vendor": "Sony",
                "model": "KDL32CX525",
                "software": "PKG4.027EUA",
                "hardware": "2011"
            },
    */

```