### PR TITLE
Fix Sharp devices(SH-L02) misjudged as Huawei devices

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -394,10 +394,10 @@
             ], [MODEL, [VENDOR, APPLE]], [
 
             // Huawei
-            /\b((?:ag[rs][23]?|bah2?|sht?|btv)-a?[lw]\d{2})\b(?!.+d\/s)/i
+            /\b((?:ag[rs][23]?|bah2?|sht|btv)-a?[lw]\d{2})\b/i
             ], [MODEL, [VENDOR, HUAWEI], [TYPE, TABLET]], [
             /(?:huawei|honor)([-\w ]+)[;\)]/i,
-            /\b(nexus 6p|\w{2,4}e?-[atu]?[ln][\dx][012359c][adn]?)\b(?!.+d\/s)/i
+            /\b(nexus 6p|(BKK|DRA|WAS|SNE|ART|AMN|JKM|MRD|JSN|LDN|YAL|VOG|ELE|CLT|EML|ANE|LYA|TET|TAH)e?-[atu]?[ln][\dx][012359c][adn]?)\b/i
             ], [MODEL, [VENDOR, HUAWEI], [TYPE, MOBILE]], [
 
             // Xiaomi

--- a/test/device-test.json
+++ b/test/device-test.json
@@ -1748,7 +1748,7 @@
     },
     {
         "desc": "Sharp Aquos L2",
-        "ua": "Mozilla/5.0 (Linux; Android 7.0; SH-L02 Build/S4045) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36",
+        "ua": "Mozilla/5.0 (Linux; Android 7.0; SH-L02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36",
         "expect": {
             "vendor": "Sharp",
             "model": "SH-L02",


### PR DESCRIPTION
fixed [#619](https://github.com/faisalman/ua-parser-js/issues/619)

>> Sharp devices(SH-L02) misjudged as Huawei devices