### PR TITLE
Implement PlayStation app `WebMAF` detection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 - What's breaking:
   - Browser detection on mobile device: `"Chrome" => "Mobile Chrome"`, `"Firefox" => "Mobile Firefox"`
   - OS detection: `"Mac OS" => "macOS"`, `"Chromium OS" => "Chrome OS"`
+  - Apps on PlayStation 4/5 now report `WebMAF` instead of `WebKit` for `browser.name` and the `WebMAF`-version in `browser.version`
 - What's new:
   - Add some new methods in result object: 
     - Add support for client hints: `withClientHints()`

--- a/src/main/ua-parser.js
+++ b/src/main/ua-parser.js
@@ -285,7 +285,7 @@
             // Mixed
             /(kindle)\/([\w\.]+)/i,                                             // Kindle
             /(lunascape|maxthon|netfront|jasmine|blazer)[\/ ]?([\w\.]*)/i,      // Lunascape/Maxthon/Netfront/Jasmine/Blazer
-            /(webmaf)\/(\S+)/i,                                                 // Sony/Playstation WebMAF
+            /(webmaf)\/([a-z0-9\.-]+)/i,                                        // Sony/Playstation WebMAF
             // Trident based
             /(avant |iemobile|slim)(?:browser)?[\/ ]?([\w\.]*)/i,               // Avant/IEMobile/SlimBrowser
             /(ba?idubrowser)[\/ ]?([\w\.]+)/i,                                  // Baidu Browser

--- a/src/main/ua-parser.js
+++ b/src/main/ua-parser.js
@@ -285,6 +285,7 @@
             // Mixed
             /(kindle)\/([\w\.]+)/i,                                             // Kindle
             /(lunascape|maxthon|netfront|jasmine|blazer)[\/ ]?([\w\.]*)/i,      // Lunascape/Maxthon/Netfront/Jasmine/Blazer
+            /(webmaf)\/(\S+)/i,                                                 // Sony/Playstation WebMAF
             // Trident based
             /(avant |iemobile|slim)(?:browser)?[\/ ]?([\w\.]*)/i,               // Avant/IEMobile/SlimBrowser
             /(ba?idubrowser)[\/ ]?([\w\.]+)/i,                                  // Baidu Browser

--- a/test/specs/browser-all.json
+++ b/test/specs/browser-all.json
@@ -1149,6 +1149,16 @@
         }
     },
     {
+        "desc"    : "Sony WebMAF SDK (Playstation)",
+        "ua"      : "Mozilla/5.0 (PlayStation 4 WebMAF) AppleWebKit/601.2 (KHTML, like Gecko) WebMAF/v3.1.0-0-ge5873ba4 SDK: (0x09508001u), Built: Nov  1 2022 14:36:14",
+        "expect"  :
+        {
+            "name"    : "WebMAF",
+            "version" : "v3.1.0-0-ge5873ba4",
+            "major"   : "3"
+        }
+    },
+    {
         "desc"    : "Swiftfox",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Firefox/2.0 (Swiftfox)",
         "expect"  :

--- a/test/specs/browser-all.json
+++ b/test/specs/browser-all.json
@@ -1159,6 +1159,16 @@
         }
     },
     {
+        "desc"    : "Sony WebMAF SDK (Playstation)",
+        "ua"      : "Mozilla/5.0 (PlayStation 5; WebMAF/1.0.0) AppleWebKit/537.73 (KHTML, like Gecko)",
+        "expect"  :
+        {
+            "name"    : "WebMAF",
+            "version" : "1.0.0",
+            "major"   : "1"
+        }
+    },
+    {
         "desc"    : "Swiftfox",
         "ua"      : "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Firefox/2.0 (Swiftfox)",
         "expect"  :


### PR DESCRIPTION
Third party apps on Playstation may use `WebMAF`, a framework provided by Sony to access specific browser functionality. This PR adds proper detection and a testcase for it.

**Example:**
UA string: `Mozilla/5.0 (PlayStation 4 WebMAF) AppleWebKit/601.2 (KHTML, like Gecko) WebMAF/v3.1.0-0-ge5873ba4 SDK: (0x09508001u), Built: Nov  1 2022 14:36:14`

Parsed result without the changes in this PR:
```javascript
    {
      os: 'PlayStation',
      osVersion: '4',
      deviceModel: 'PlayStation 4',
      deviceType: 'console',
      browser: 'Webkit',
      browserVersion: '601.2'
    }
```

Parsed result with this PR:
```javascript
    {
      os: 'PlayStation',
      osVersion: '4',
      deviceModel: 'PlayStation 4',
      deviceType: 'console',
      browser: 'WebMAF',
      browserVersion: 'v3.1.0-0-ge5873ba4'
    }
```
