### PR TITLE
Fix Amazon Fire TV device detection

### DIFF
--- a/src/main/ua-parser.js
+++ b/src/main/ua-parser.js
@@ -627,7 +627,7 @@
             ], [VENDOR, [MODEL, APPLE+' TV'], [TYPE, SMARTTV]], [
             /crkey/i                                                            // Google Chromecast
             ], [[MODEL, CHROME+'cast'], [VENDOR, GOOGLE], [TYPE, SMARTTV]], [
-            /droid.+aft(\w)( bui|\))/i                                          // Fire TV
+            /droid.+aft(\w+)( bui|\))/i                                         // Fire TV
             ], [MODEL, [VENDOR, AMAZON], [TYPE, SMARTTV]], [
             /\(dtv[\);].+(aquos)/i,
             /(aquos-tv[\w ]+)\)/i                                               // Sharp

--- a/test/specs/device-all.json
+++ b/test/specs/device-all.json
@@ -2773,6 +2773,15 @@
         }
     },
     {
+        "desc": "Amazon Fire TV",
+        "ua": "Mozilla/5.0 (Linux; Android 9; AFTKA Build/PS7633.3445N; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/108.0.5359.160 Mobile Safari/537.36",
+        "expect": {
+            "vendor": "Amazon",
+            "model": "KA",
+            "type": "smarttv"
+        }
+    },
+    {
         "desc": "Android TV",
         "ua": "Mozilla/5.0 (Linux; Android 10; 2020/2021 UHD Android TV Build/QTG3.201102.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) version/4.0 Chrome/83.0.4103.101 Mobile Safari/537.36",
         "expect": {


### PR DESCRIPTION
Add support for more Amazon Fire TV models: https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html 