### PR TITLE
feat: add Klarna Shopping Browser UA parser

### DIFF
--- a/src/main/ua-parser.js
+++ b/src/main/ua-parser.js
@@ -85,6 +85,7 @@
         FIREFOX     = 'Firefox',
         OPERA       = 'Opera',
         FACEBOOK    = 'Facebook',
+        KLARNA      = 'Klarna',
         WINDOWS     = 'Windows';
    
     var NAVIGATOR           = (typeof window !== UNDEF_TYPE && window.navigator) ? 
@@ -354,6 +355,8 @@
             // WebView
             /((?:fban\/fbios|fb_iab\/fb4a)(?!.+fbav)|;fbav\/([\w\.]+);)/i       // Facebook App for iOS & Android
             ], [[NAME, FACEBOOK], VERSION], [
+            /(Klarna)\/([\w\.]+)/i                                              // Klarna Shopping Browser for iOS & Android
+            ], [[NAME, KLARNA], VERSION], [
             /(kakao(?:talk|story))[\/ ]([\w\.]+)/i,                             // Kakao App
             /(naver)\(.*?(\d+\.[\w\.]+).*\)/i,                                  // Naver InApp
             /safari (line)\/([\w\.]+)/i,                                        // Line App for iOS

--- a/test/specs/browser-all.json
+++ b/test/specs/browser-all.json
@@ -430,6 +430,26 @@
         }
     },
     {
+        "desc"    : "Klarna in-App Browser for iOS",
+        "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Klarna/23.36.223",
+        "expect"  :
+        {
+            "name"    : "Klarna",
+            "version" : "23.36.223",
+            "major"   : "23"
+        }
+    },
+    {
+        "desc"    : "Klarna in-App Browser for Android",
+        "ua"      : "Mozilla/5.0 (Linux; Android 12; moto g(60)s Build/S3RLS32.114-25-13; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/116.0.0.0 Mobile Safari/537.36 Klarna/23.36.215",
+        "expect"  :
+        {
+            "name"    : "Klarna",
+            "version" : "23.36.215",
+            "major"   : "23"
+        }
+    },
+    {
         "desc"    : "Instagram in-App Browser for iOS",
         "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 14_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 142.0.0.22.109 (iPhone12,5; iOS 14_1; en_US; en-US; scale=3.00; 1242x2688; 214888322) NW/1",
         "expect"  :


### PR DESCRIPTION
Klarna App with 150 million users is rather popular shopping browser.

Adding support for Klarna UA parser.