### PR TITLE
Fix: Add "types" inside "exports" of package.json, fix ./helpers export typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
   "exports": {
     ".": {
       "require": "./src/main/ua-parser.js",
-      "import": "./src/main/ua-parser.mjs"
+      "import": "./src/main/ua-parser.mjs",
+      "types": "./src/main/ua-parser.d.ts"
     },
     "./enums": {
       "require": "./src/enums/ua-parser-enums.js",
@@ -185,8 +186,9 @@
       "import": "./src/extensions/ua-parser-extensions.mjs"
     },
     "./helpers": {
-      "require": "./src/extensions/ua-parser-helpers.js",
-      "import": "./src/extensions/ua-parser-helpers.mjs"
+      "require": "./src/helpers/ua-parser-helpers.js",
+      "import": "./src/helpers/ua-parser-helpers.mjs",
+      "types": "./src/helpers/ua-parser-helpers.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
# Prerequisites

- [x] I have read and follow the contributing guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Bug fix

# Description

In order for [Typescript Bundler Resolution](https://github.com/microsoft/TypeScript/pull/51669) to work types path also need to be listed inside "exports" field. 

![image](https://github.com/faisalman/ua-parser-js/assets/10450717/79a0f4b7-c8a6-4390-8a3a-fc05a2b3d5c1)

I have also fixed incorrect ./helpers export.

# Test

Are not needed.

# Impact

No breaking change

# Other Info