### PR TITLE
Fix for Xbox Detection

### DIFF
--- a/src/main/ua-parser.js
+++ b/src/main/ua-parser.js
@@ -1080,6 +1080,11 @@
                     if (uaCH[MODEL]) {
                         this.set(MODEL, uaCH[MODEL]);
                     }
+                    // Xbox-Specific Detection
+                    if (uaCH[MODEL] == 'Xbox') {
+                        this.set(TYPE, CONSOLE);
+                        this.set(VENDOR, MICROSOFT);
+                    }
                     if (uaCH[FORMFACTOR]) {
                         var ff;
                         if (typeof uaCH[FORMFACTOR] !== 'string') {
@@ -1101,6 +1106,11 @@
                         this.set(NAME, osName)
                             .set(VERSION, osVersion);
                     }
+                    // Xbox-Specific Detection
+                    if (this.get(NAME) == WINDOWS && uaCH[MODEL] == 'Xbox') {
+                        this.set(NAME, 'Xbox')
+                        this.set(VERSION, undefined)
+                    }           
                     break;
                 case UA_RESULT:
                     var data = this.data;


### PR DESCRIPTION
Fixed Xbox Detection for Chrome-Based Edge

# Prerequisites

- [x] I have read and follow the contributing guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Bug fix,

# Description

In 2020, Microsoft changed their browser Edge to use Chromium. 
Xbox now uses that Chromium Edge browser. 
With Chromium "Xbox" is no longer included  in the user agent

Before Chromium, the User-Agent looked like this:
```
Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.17748
```

With Chromium the user agent from the console is:
```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0
```

However, Xbox is still present inside of the Client Hint  `Sec-CH-UA-Model`.

# Test

I tested this implementation on the demo page

### Before
 |   |   |
|---|---|
| ![image](https://github.com/faisalman/ua-parser-js/assets/66485277/9ecfde74-47dd-4d8e-8ab6-f4858ea863e0) | ![image](https://github.com/faisalman/ua-parser-js/assets/66485277/814ca390-457b-47e1-8d8f-3585b4e7fff0) |

### After
 |   |   |
|---|---|
| ![image](https://github.com/faisalman/ua-parser-js/assets/66485277/96620ed6-9301-410a-877f-d19afc858dc3) | ![image](https://github.com/faisalman/ua-parser-js/assets/66485277/819840d9-20b9-4472-9539-0cdfb0f3ec16) |



# Impact

To sum it up, this fixes Xbox detection for ua-parser-js!

# Other Info
While the old Xbox user-agent did include the version of the console (Xbox One), it is no longer included in the newer User-Agent, meaning that `os.version`  will have to stay undefined, as it is not possible to detect it.

Reference: [Old Xbox agent on the demo page](https://uaparser.js.org/?ua=Mozilla/5.0%20(Windows%20NT%2010.0;%20Win64;%20x64;%20Xbox;%20Xbox%20One)%20AppleWebKit/537.36%20(KHTML,%20like%20Gecko)%20Chrome/64.0.3282.140%20Safari/537.36%20Edge/18.17748)