### PR TITLE
feat: Update and expand Chromecast device families

### DIFF
--- a/src/main/ua-parser.js
+++ b/src/main/ua-parser.js
@@ -81,6 +81,7 @@
         PREFIX_MOBILE  = 'Mobile ',
         SUFFIX_BROWSER = ' Browser',
         CHROME      = 'Chrome',
+        CHROMECAST  = 'Chromecast',
         EDGE        = 'Edge',
         FIREFOX     = 'Firefox',
         OPERA       = 'Opera',
@@ -670,8 +671,14 @@
             ], [[VENDOR, LG], [TYPE, SMARTTV]], [
             /(apple) ?tv/i                                                      // Apple TV
             ], [VENDOR, [MODEL, APPLE+' TV'], [TYPE, SMARTTV]], [
-            /crkey/i                                                            // Google Chromecast
-            ], [[MODEL, CHROME+'cast'], [VENDOR, GOOGLE], [TYPE, SMARTTV]], [
+            /crkey.*devicetype\/chromecast/i                                    // Google Chromecast Third Generation
+            ], [[MODEL, CHROMECAST+' Third Generation'], [VENDOR, GOOGLE], [TYPE, SMARTTV]], [
+            /crkey.*devicetype\/([^/]*)/i                                       // Google Chromecast with specific device type
+            ], [[MODEL, /^/, 'Chromecast '], [VENDOR, GOOGLE], [TYPE, SMARTTV]], [
+            /fuchsia.*crkey/i                                                   // Google Chromecast Nest Hub
+            ], [[MODEL, CHROMECAST+' Nest Hub'], [VENDOR, GOOGLE], [TYPE, SMARTTV]], [
+            /crkey/i                                                            // Google Chromecast, Linux-based or unknown
+            ], [[MODEL, CHROMECAST], [VENDOR, GOOGLE], [TYPE, SMARTTV]], [
             /droid.+aft(\w+)( bui|\))/i                                         // Fire TV
             ], [MODEL, [VENDOR, AMAZON], [TYPE, SMARTTV]], [
             /\(dtv[\);].+(aquos)/i,
@@ -784,6 +791,18 @@
             /(macintosh|mac_powerpc\b)(?!.+haiku)/i                             // Mac OS
             ], [[NAME, 'macOS'], [VERSION, /_/g, '.']], [
 
+            // Google Chromecast
+            /android ([\d\.]+).*crkey/i                                         // Google Chromecast, Android-based
+            ], [VERSION, [NAME, CHROMECAST + ' Android']], [
+            /fuchsia.*crkey\/([\d\.]+)/i                                        // Google Chromecast, Fuchsia-based
+            ], [VERSION, [NAME, CHROMECAST + ' Fuchsia']], [
+            /crkey\/([\d\.]+).*devicetype\/smartspeaker/i                       // Google Chromecast, Linux-based Smart Speaker
+            ], [VERSION, [NAME, CHROMECAST + ' SmartSpeaker']], [
+            /linux.*crkey\/([\d\.]+)/i                                          // Google Chromecast, Legacy Linux-based
+            ], [VERSION, [NAME, CHROMECAST + ' Linux']], [
+            /crkey\/([\d\.]+)/i                                                 // Google Chromecast, unknown
+            ], [VERSION, [NAME, CHROMECAST]], [
+
             // Mobile OSes
             /droid ([\w\.]+)\b.+(android[- ]x86|harmonyos)/i                    // Android-x86/HarmonyOS
             ], [VERSION, NAME], [                                               // Android/WebOS/QNX/Bada/RIM/Maemo/MeeGo/Sailfish OS
@@ -804,9 +823,7 @@
             /watch(?: ?os[,\/]|\d,\d\/)([\d\.]+)/i                              // watchOS
             ], [VERSION, [NAME, 'watchOS']], [
 
-            // Google Chromecast
-            /crkey\/([\d\.]+)/i                                                 // Google Chromecast
-            ], [VERSION, [NAME, CHROME+'cast']], [
+            // Google ChromeOS
             /(cros) [\w]+(?:\)| ([\w\.]+)\b)/i                                  // Chromium OS
             ], [[NAME, "Chrome OS"], VERSION],[
 

--- a/test/specs/device-all.json
+++ b/test/specs/device-all.json
@@ -3024,6 +3024,42 @@
         }
     },
     {
+        "desc": "Google Chromecast with Google TV",
+        "ua": "Mozilla/5.0 (Linux; Android 12.0; Build/STTL.240206.002) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.0 Safari/537.36 CrKey/1.56.500000 DeviceType/AndroidTV",
+        "expect": {
+            "vendor": "Google",
+            "model": "Chromecast AndroidTV",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "Google Chromecast Mini Smart Speaker",
+        "ua": "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000 DeviceType/SmartSpeaker",
+        "expect": {
+            "vendor": "Google",
+            "model": "Chromecast SmartSpeaker",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "Google Chromecast Third Generation",
+        "ua": "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000 DeviceType/Chromecast",
+        "expect": {
+            "vendor": "Google",
+            "model": "Chromecast Third Generation",
+            "type": "smarttv"
+        }
+    },
+    {
+        "desc": "Google Chromecast Nest Hub",
+        "ua": "Mozilla/5.0 (Fuchsia) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 CrKey/1.56.500000",
+        "expect": {
+            "vendor": "Google",
+            "model": "Chromecast Nest Hub",
+            "type": "smarttv"
+        }
+    },
+    {
         "desc": "Google Chromecast",
         "ua": "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.84 Safari/537.36 CrKey/1.22.79313",
         "expect": {

--- a/test/specs/os-all.json
+++ b/test/specs/os-all.json
@@ -414,11 +414,38 @@
         }
     },
     {
-        "desc"    : "Google Chromecast",
+        "desc"    : "Google Chromecast with Google TV",
+        "ua"      : "Mozilla/5.0 (Linux; Android 12.0; Build/STTL.240206.002) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.0 Safari/537.36 CrKey/1.56.500000 DeviceType/AndroidTV",
+        "expect"  :
+        {
+            "name"    : "Chromecast Android",
+            "version" : "12.0"
+        }
+    },
+    {
+        "desc"    : "Google Chromecast Nest Hub",
+        "ua"      : "Mozilla/5.0 (Fuchsia) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 CrKey/1.56.500000",
+        "expect"  :
+        {
+            "name"    : "Chromecast Fuchsia",
+            "version" : "1.56.500000"
+        }
+    },
+    {
+        "desc"    : "Google Chromecast Mini Smart Speaker",
+        "ua"      : "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000 DeviceType/SmartSpeaker",
+        "expect"  :
+        {
+            "name"    : "Chromecast SmartSpeaker",
+            "version" : "1.56.500000"
+        }
+    },
+    {
+        "desc"    : "Google Chromecast Legacy Linux-Based",
         "ua"      : "Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.81 Safari/537.36 CrKey/1.42.183786",
         "expect"  :
         {
-            "name"    : "Chromecast",
+            "name"    : "Chromecast Linux",
             "version" : "1.42.183786"
         }
     },


### PR DESCRIPTION
# Prerequisites

- [X] I have read and follow the contributing guidelines
- [X] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Feature

# Description

Update and expand Chromecast device families.  This adds support to differentiate between types of Chromecast devices and operating systems, and fixes erroneous classification of Android-based Chromecasts.

# Test

Extracted several current useragent strings from various device types in a lab, then added them to the automated tests in us-parser-js.  These tests are passing.

# Impact

No breaking changes AFAICT.

# Other Info

I'm a current member of the Chromecast team at Google, as well as the TL for the open source [Shaka Player](https://github.com/shaka-project/shaka-player/).  We test our video player on many, many devices in a lab using [Karma](https://github.com/karma-runner/karma), which uses ua-parser-js to match test results to each device.  We need these changes to differentiate between the Chromecast devices in our lab.