### PR TITLE
Add missing 1.0.39 changes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,14 @@
 
 ---
 
+## Version 0.7.39 / 1.0.39
+- Add new feature: executable command using `npx ua-parser-js "[INSERT-UA-HERE]"`
+- Add new browser: Helio, Pico Browser, Wolvic
+- Add new device vendor: itel, Nothing, TCL
+- Improve browser detection: ICEBrowser, Klar, QQBrowser, Quark, Rekonq, Sleipnir
+- Improve device detection: Xiaomi Pro, Amazon Echo Show, Samsung Galaxy Watch
+- Removed from browser: Viera
+  
 ## Version 0.7.38 / 1.0.38
 - Fix error on getOS() when userAgentData.platform is undefined
 - Add new browser: Opera GX, Twitter


### PR DESCRIPTION
# Prerequisites

- [x] I have read and follow the contributing guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

docs

# Description

It looks like the 1.0.39 changelog entries were kinda kicked-out, probably during the merge of v2.x?
This PR reintroduces the missing changelog entries.

# Impact

No impact for users.
