### PR TITLE
chore: move node-fetch to devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@types/node-fetch": "^2.6.12",
         "detect-europe-js": "^0.1.2",
         "is-standalone-pwa": "^0.1.1",
-        "node-fetch": "^2.7.0",
         "ua-is-frozen": "^0.1.2"
       },
       "bin": {
@@ -38,6 +37,7 @@
         "@playwright/test": "^1.49.0",
         "jshint": "~2.13.6",
         "mocha": "~8.2.0",
+        "node-fetch": "^2.7.0",
         "requirejs": "2.3.2",
         "safe-regex": "^2.1.1",
         "tsd": "^0.29.0",
@@ -1967,6 +1967,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2716,7 +2717,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
@@ -2809,12 +2811,14 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -227,7 +227,6 @@
     "detect-europe-js": "^0.1.2",
     "is-standalone-pwa": "^0.1.1",
     "ua-is-frozen": "^0.1.2",
-    "node-fetch": "^2.7.0",
     "@types/node-fetch": "^2.6.12"
   },
   "devDependencies": {
@@ -236,6 +235,7 @@
     "@playwright/test": "^1.49.0",
     "jshint": "~2.13.6",
     "mocha": "~8.2.0",
+    "node-fetch": "^2.7.0",
     "requirejs": "2.3.2",
     "safe-regex": "^2.1.1",
     "tsd": "^0.29.0",


### PR DESCRIPTION
# Prerequisites

- [x] I have read and follow the [contributing](https://github.com/faisalman/ua-parser-js/blob/master/CONTRIBUTING.md) guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Moved `node-fetch` to depDeps

# Description

`node-fetch` is only used in tests, it should be safe to be moved into devDeps.

The typings file imported `Headers` type from `node-fetch` so `@types/node-fetch` was kept as dependency.
