### PR TITLE
chore: Replace Undici by native Headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
       "dependencies": {
         "detect-europe-js": "^0.1.2",
         "is-standalone-pwa": "^0.1.1",
-        "ua-is-frozen": "^0.1.2",
-        "undici": "^7.12.0"
+        "ua-is-frozen": "^0.1.2"
       },
       "bin": {
         "ua-parser-js": "script/cli.js"
@@ -2691,15 +2690,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
-      "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -226,8 +226,7 @@
   "dependencies": {
     "detect-europe-js": "^0.1.2",
     "is-standalone-pwa": "^0.1.1",
-    "ua-is-frozen": "^0.1.2",
-    "undici": "^7.12.0"
+    "ua-is-frozen": "^0.1.2"
   },
   "devDependencies": {
     "@babel/parser": "7.15.8",

--- a/src/main/ua-parser.d.ts
+++ b/src/main/ua-parser.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/faisalman/ua-parser-js
 // Definitions by: Faisal Salman <https://github.com/faisalman>
 
-import type { Headers } from "undici";
 import { BrowserType, CPUArch, DeviceType, EngineName } from "../enums/ua-parser-enums";
 
 declare namespace UAParser {

--- a/test/unit/main.js
+++ b/test/unit/main.js
@@ -10,7 +10,6 @@ var cpus        = require('../data/ua/cpu/cpu-all.json');
 var devices     = readJsonFiles('test/data/ua/device');
 var engines     = require('../data/ua/engine/engine-all.json');
 var os          = readJsonFiles('test/data/ua/os');
-var { Headers } = require('undici');
 
 function readJsonFiles(dir) {
     var list = [];


### PR DESCRIPTION
# Prerequisites

- [x] I have read and follow the [contributing](https://github.com/faisalman/ua-parser-js/blob/master/CONTRIBUTING.md) guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Optimization

# Description

Replace the `undici` dependency with the native [`Headers`](https://developer.mozilla.org/Web/API/Headers) class. This removes a 1.5 MB dependency.

# Test

I ran the unit tests, which passed. I don't know how to really test this change.

# Impact

There is no change for the user.

# Other Info

`Headers` was added in Node 18 ([_Undici_](https://github.com/nodejs/undici/blob/v7.12.0/package.json#L133) required Node 20).