### PR TITLE
Fix: remove desktop from enums according to documentation

### DIFF
--- a/src/enums/ua-parser-enums.d.ts
+++ b/src/enums/ua-parser-enums.d.ts
@@ -211,7 +211,6 @@ export const CPU: typeof CPUArch;
 
 export const DeviceType: Readonly<{
     CONSOLE: 'console',
-    DESKTOP: 'desktop',
     EMBEDDED: 'embedded',
     MOBILE: 'mobile',
     SMARTTV: 'smarttv',

--- a/src/enums/ua-parser-enums.js
+++ b/src/enums/ua-parser-enums.js
@@ -208,7 +208,6 @@ const CPU = CPUArch;
 
 const DeviceType = Object.freeze({
     CONSOLE: 'console',
-    DESKTOP: 'desktop',
     EMBEDDED: 'embedded',
     MOBILE: 'mobile',
     SMARTTV: 'smarttv',

--- a/src/enums/ua-parser-enums.mjs
+++ b/src/enums/ua-parser-enums.mjs
@@ -211,7 +211,6 @@ const CPU = CPUArch;
 
 const DeviceType = Object.freeze({
     CONSOLE: 'console',
-    DESKTOP: 'desktop',
     EMBEDDED: 'embedded',
     MOBILE: 'mobile',
     SMARTTV: 'smarttv',


### PR DESCRIPTION
# Prerequisites

- [x] I have read and follow the [contributing](https://github.com/faisalman/ua-parser-js/blob/master/CONTRIBUTING.md) guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Typescript bug fix

# Description

According to the [documentation](https://docs.uaparser.dev/info/device/type.html), the `IDevice` type should not include `'desktop'` as a valid value. I've removed this property from the `DeviceType` object in `./src/enums/ua-parser-enums.js` and updated the corresponding TypeScript definition files.

# Test

All unit tests passed.

# Impact

This change may affect users who were previously using `'desktop'` as a device type value in their TypeScript code. However, since this value is not officially supported according to the documentation, these users were likely relying on incorrect type definitions. The update brings TypeScript definitions in line with the actual library behavior and documented specifications.

Users who were incorrectly using `'desktop'` will now get TypeScript errors, guiding them to use the officially supported device types instead.