### PR TITLE
chore: update pattern to ONLY include top-level js files in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     }
   },
   "files": [
-    "dist",
+    "dist/*.?(m)js",
     "src"
   ],
   "bin": "./script/cli.js",


### PR DESCRIPTION
# Prerequisites

- [X] I have read and follow the [contributing](https://github.com/faisalman/ua-parser-js/blob/master/CONTRIBUTING.md) guidelines
- [X] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

chore

# Description

Update pattern in `files` field to ONLY include top-level JavaScript files in `dist` directory when publishing.
The JavaScript files are:
- `dist/ua-parser.min.js`
- `dist/ua-parser.min.mjs`
- `dist/ua-parser.pack.js.`
- `dist/ua-parser.pack.mjs`

Don't worry, this change is ONLY affected to `dist` directory.

# Test

Nothing

# Impact

Nothing

# Other Info

You can run `npm pack` to see differents.

Before:
```
npm notice package size: 771.9 kB
npm notice unpacked size: 1.3 MB
```
After:
```
npm notice package size: 150.0 kB
npm notice unpacked size: 477.8 kB
```
