### PR TITLE
[extensions] Add new crawlers: Meta-WebIndexer, Meta-ExternalAds

### DIFF
--- a/src/extensions/ua-parser-extensions.js
+++ b/src/extensions/ua-parser-extensions.js
@@ -102,7 +102,7 @@ const Crawlers = Object.freeze({
 
             // Facebook / Meta 
             // https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
-            /(facebook(?:externalhit|catalog)|meta-externalagent)\/([\w\.]+)/i,
+            /(facebook(?:externalhit|catalog)|meta-(?:externalagent|externalads|webindexer))\/([\w\.]+)/i,
 
             // Googlebot - http://www.google.com/bot.html
             /(google(?:bot|other|-inspectiontool)(?:-image|-video|-news)?|storebot-google)\/?([\w\.]*)/i, 

--- a/test/data/ua/extension/crawler.json
+++ b/test/data/ua/extension/crawler.json
@@ -950,6 +950,26 @@
         }
     },
     {
+        "desc"    : "Meta-ExternalAds",
+        "ua"      : "meta-externalads/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)",
+        "expect"  :
+        {
+            "name"    : "meta-externalads",
+            "version" : "1.1",
+            "type"    : "crawler"
+        }
+    },
+    {
+        "desc"    : "Meta-WebIndexer",
+        "ua"      : "meta-webindexer/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)",
+        "expect"  :
+        {
+            "name"    : "meta-webindexer",
+            "version" : "1.1",
+            "type"    : "crawler"
+        }
+    },
+    {
         "desc"    : "MJ12bot",
         "ua"      : "Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)",
         "expect"  :


### PR DESCRIPTION
# Prerequisites

- [x] I have read and follow the [contributing](https://github.com/faisalman/ua-parser-js/blob/master/CONTRIBUTING.md) guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Adds new crawlers.


# Description

Added two new crawlers from Meta, see https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/

# Test

Extended `crawler.json` and `ua-parser-extensions.js` to pass the tests.

# Impact

Now detects all listed Meta crawlers.


# Other Info

Excluded `Meta-ExternalFetcher` as it is initiated by the user when embedding an URL.