### PR TITLE
TypeScript configuration recommendations for issue #736

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1166,7 +1165,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1412,7 +1410,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2026,7 +2023,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -194,6 +194,28 @@
   ],
   "type": "commonjs",
   "types": "src/main/ua-parser.d.ts",
+  "typesVersions": {
+    "*": {
+      "bot-detection": [
+        "src/bot-detection/bot-detection.d.ts"
+      ],
+      "browser-detection": [
+        "src/browser-detection/browser-detection.d.ts"
+      ],
+      "device-detection": [
+        "src/device-detection/device-detection.d.ts"
+      ],
+      "enums": [
+        "src/enums/ua-parser-enums.d.ts"
+      ],
+      "extensions": [
+        "src/extensions/ua-parser-extensions.d.ts"
+      ],
+      "helpers": [
+        "src/helpers/ua-parser-helpers.d.ts"
+      ]
+    }
+  },
   "main": "src/main/ua-parser.js",
   "module": "src/main/ua-parser.mjs",
   "browser": "dist/ua-parser.pack.js",


### PR DESCRIPTION
To avoid the "Cannot find module 'ua-parser-js/enums' or its corresponding type declarations" error in TypeScript, users should ensure their `tsconfig.json` is configured to handle the `exports` field in `package.json`.

Recommendations:
1. Set `moduleResolution` to `NodeNext`, `Node16`, or `bundler`.
2. Ensure the `module` option is compatible with the chosen `moduleResolution` (e.g., `NodeNext` or `Node16`).
3. Use `esModuleInterop: true` to handle CommonJS/ESM interop correctly.
4. Note that exported enum names in `ua-parser-js/enums` are PascalCase (e.g., `Browser`, `OS`, `Device`) rather than uppercase.

Example `tsconfig.json`:
```json
{
  "compilerOptions": {
    "module": "NodeNext",
    "moduleResolution": "NodeNext",
    "esModuleInterop": true
  }
}
```

Example usage:
```typescript
import { UAParser } from 'ua-parser-js';
import { Browser } from 'ua-parser-js/enums';

console.log(Browser.CHROME);
```

---
*PR created automatically by Jules for task [1506158762762933570](https://jules.google.com/task/1506158762762933570) started by @faisalman*