### PR TITLE
feat(inapps): detect ChatGPT desktop app

### DIFF
--- a/src/enums/ua-parser-enums.js
+++ b/src/enums/ua-parser-enums.js
@@ -782,6 +782,7 @@ const Extension = Object.freeze({
             ZOOMINFO_BOT: 'Zoombot'
         },
         InApp: {
+            CHATGPT: 'ChatGPT',
             DISCORD: 'Discord',
             EVERNOTE: 'Evernote',
             FIGMA: 'Figma',

--- a/src/extensions/ua-parser-extensions.js
+++ b/src/extensions/ua-parser-extensions.js
@@ -361,6 +361,10 @@ const Fetchers = Object.freeze({
 
 const InApps = Object.freeze({
     browser : [[
+        // ChatGPT
+        /\bcodex\/([\w\.]+).+electron\//i],
+        [VERSION, [NAME, 'ChatGPT'], [TYPE, INAPP]], [
+
         // Discord/Figma/Flipboard/Mattermost/Notion/Postman/Rambox/Rocket.Chat/Slack/Teams
         /\b(discord|figma|mattermost|notion|postman|rambox|rocket.chat|slack|teams)\/([\w\.]+).+(electron\/|; ios)/i,
         /(flipboard)\/([\w\.]+)/i

--- a/test/data/ua/extension/inapp.json
+++ b/test/data/ua/extension/inapp.json
@@ -1,5 +1,15 @@
 [
     {
+        "desc"    : "ChatGPT on Mac",
+        "ua"      : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Codex/26.513.31313 Chrome/148.0.7778.97 Electron/42.0.1 Safari/537.36",
+        "expect"  :
+        {
+            "name"    : "ChatGPT",
+            "version" : "26.513.31313",
+            "type"    : "inapp"
+        }
+    },
+    {
         "desc"    : "Discord on Linux",
         "ua"      : "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) discord/0.0.26 Chrome/108.0.5359.215 Electron/22.3.2 Safari/537.36",
         "expect"  :


### PR DESCRIPTION
# Prerequisites

- [x] I have read and follow the [contributing](https://github.com/faisalman/ua-parser-js/blob/master/CONTRIBUTING.md) guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Feature

# Description

Map the `Codex/` product token emitted by the ChatGPT desktop app to ChatGPT through the `InApps` extension instead of falling back to Electron. This adds the ChatGPT in-app enum and a detection fixture based on a user agent reproduced by the public UAParser.js demo.

OpenAI now brands the desktop application as ChatGPT and describes Codex as a capability within that app: https://learn.chatgpt.com/

Fixes #843.

# Test

`npm run test` completed the build, JSHint, ESLint, and Mocha stages. The local browser stage was not completed.

# Impact

No breaking change. Consumers using the `InApps` extension will receive ChatGPT as the browser name and `inapp` as its type for matching `Codex/` desktop user agents.

# Other Info

None.